### PR TITLE
Sakari/combine examples for doc node

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -26,15 +26,15 @@ main = do
 
     --  * testCommentLocation
       , doctest "." ["testCommentLocation/Foo.hs"]
-        (cases 11)
+        (cases 8)
 
     -- * testPutStr
       , doctest "testPutStr" ["Fib.hs"]
-        (cases 2)
+        (cases 1)
 
     -- * testFailOnMultiline
       , doctest "testFailOnMultiline" ["Fib.hs"]
-        (cases 2) {errors = 2}
+        (cases 1) {errors = 1}
 
     -- * testNotInScope
       , doctest "testNotInScope" ["Fib.hs"]
@@ -51,7 +51,7 @@ main = do
       , doctest "bugfixWorkingDirectory" ["Fib.hs"]
         (cases 1)
       , doctest "bugfixWorkingDirectory" ["examples/Fib.hs"]
-        (cases 2)
+        (cases 1)
 
     -- * bugfixOutputToStdErr
       , doctest "bugfixOutputToStdErr" ["Fib.hs"]

--- a/tests/testCommentLocation/Foo.hs
+++ b/tests/testCommentLocation/Foo.hs
@@ -41,7 +41,8 @@ module Foo (
 test :: Integer -> Integer
 test = undefined
 
--- |
+-- | Note that examples for 'fib' include the two examples below
+-- and the one example with ^ syntax after 'fix'
 -- >>> foo
 -- "foo"
 


### PR DESCRIPTION
Hi

Would you be interested in a patch to combine all the examples for a doc node together. The idea is that
with this you can intersperse comments between a continuing example:

```
-- | Like this
--
-- >>> let a = 1
-- 
-- a is given value 1
--
-- >>> print a
-- "1"
```

(There was also one failing test case before my work. I changed the expected results for it so that all tests pass without that much thought so you might want to take a look on it) 
