### PR TITLE
Sakari/wait for interpreter to close

### DIFF
--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -6,6 +6,8 @@ module Interpreter (
 
 import System.IO
 import System.Process
+import System.Exit
+import Control.Monad(when)
 import Control.Exception (bracket)
 import Data.Char
 import Data.List
@@ -58,8 +60,8 @@ closeInterpreter :: Interpreter -> IO ()
 closeInterpreter repl = do
   hClose $ hIn repl
   hClose $ hOut repl
-
-  _ <- waitForProcess $ process repl
+  e <- waitForProcess $ process repl
+  when (e /= ExitSuccess) $ error $ "Interpreter exited with an error: " ++ show e 
   return ()
 
 putExpression :: Interpreter -> String -> IO ()


### PR DESCRIPTION
this pull request is related to issue #3

I'm dogfooding the test-framework-doctest on my own project (hgit) and this saves me from a hanging ghc process after the test run. The immediate benefit to the doctest executable is not that big but both waiting for the interpreter and checking the exit code would make also the executable generally more robust.

The downside is that there is no test case for this and that these commits do not seem to prevent the ghc process from being left hanging when the doctest binary is stopped violently. 
