### PR TITLE
empty results should be True.

### DIFF
--- a/src/DocTest.hs
+++ b/src/DocTest.hs
@@ -36,8 +36,9 @@ toAssertion repl test = do
         exampleResult $ lines result'
       where
         exampleExpression = expression x
-        exampleResult     = map subBlankLines $ result x
-
+        exampleResult     = case map subBlankLines $ result x of
+            [] -> ["True"]
+            xs -> xs
         -- interpret lines that only contain the string "<BLANKLINE>" as an
         -- empty line
         subBlankLines "<BLANKLINE>" = ""


### PR DESCRIPTION
This patch treats empty result as True. With this patch, the Data.Map style doctest:

> > > size (fromList([(1,'a'), (2,'c'), (3,'b')])) == 3

Currently, Data.Map uses

> size (fromList([(1,'a'), (2,'c'), (3,'b')])) == 3

If this patch is merged, I will ask to translate "> " to ">>> " to the maintainers of the containers package. 

This behavior does not need to be default. If you provide any option to enables this behavior, I would be very happy.
