### PR TITLE
Added doctest executable location on Mac OSX to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,6 +17,9 @@ Install it, by typing:
 
     cabal install doctest
 
+On Mac OS X, you may wish to place `~/Library/Haskell/bin` on your `PATH`:
+    
+    export PATH="$HOME/Library/Haskell/bin:$PATH"
 
 Usage
 =====


### PR DESCRIPTION
It is not apparent, especially if this is the first cabal package you are installing.

I found it by reading ~/.cabal/config.
