### PR TITLE
Handle GHC 7.4's "Not in scope"

### DIFF
--- a/src/Property.hs
+++ b/src/Property.hs
@@ -47,7 +47,7 @@ freeVariables repl term = do
   r <- fmap lines `fmap` Interpreter.safeEval repl (":type " ++ term)
   case r of
     Right err -> do
-      return (nub . map extractVariable . filter (": Not in scope: " `isInfixOf`) $ err)
+      return (nub . map extractVariable . filter ("Not in scope: " `isInfixOf`) $ err)
     _ ->
       return []
   where

--- a/test/PropertySpec.hs
+++ b/test/PropertySpec.hs
@@ -26,6 +26,9 @@ spec = do
     it "runs an implicitly quantified property" $ withInterpreter [] $ \repl -> do
       runProperty repl (noLocation "(reverse . reverse) xs == (xs :: [Int])") `shouldReturn` Success
 
+    it "runs an implicitly quantified property even with GHC 7.4" $ withInterpreter [] $ \repl -> do
+      runProperty repl (noLocation "foldr (+) 0 is == sum (is :: [Int])") `shouldReturn` Success
+
     it "runs an explicitly quantified property" $ withInterpreter [] $ \repl -> do
       runProperty repl (noLocation "\\xs -> (reverse . reverse) xs == (xs :: [Int])") `shouldReturn` Success
 


### PR DESCRIPTION
GHC 7.4 sometime guesses what the variable means:

```
<interactive>:1:13:
    Not in scope: `is'
    Perhaps you meant one of these:
      `it' (line 6), `id' (imported from Prelude)
```

So, ": Not in scope" cannot catch this.
