### PR TITLE
GHC 7.6.1 compatibility

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -43,8 +43,8 @@ library
     , Type
     , Util
   build-depends:
-      base        >= 4.0  && < 4.6
-    , ghc         >= 6.12 && < 7.6
+      base        >= 4.0  && < 4.7
+    , ghc         >= 6.12 && < 7.8
     , syb
     , deepseq
     , directory
@@ -61,7 +61,7 @@ executable doctest
   hs-source-dirs:
       driver
   build-depends:
-      base        >= 4.0  && < 4.6
+      base        >= 4.0  && < 4.7
     , doctest
 
 test-suite spec
@@ -76,8 +76,8 @@ test-suite spec
   hs-source-dirs:
       src, test
   build-depends:
-      base        >= 4.0  && < 4.6
-    , ghc         >= 6.12 && < 7.6
+      base        >= 4.0  && < 4.7
+    , ghc         >= 6.12 && < 7.8
     , syb
     , deepseq
     , directory

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -1,7 +1,11 @@
-{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving, DeriveFunctor #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, StandaloneDeriving, DeriveFunctor #-}
 module Extract (Module(..), extract) where
 
-import           Prelude hiding (mod, catch)
+import           Prelude hiding (mod
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 706
+  , catch
+#endif
+  )
 import           Control.Monad
 import           Control.Applicative
 import           Control.Exception

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -8,7 +8,10 @@ module Run (
 #endif
 ) where
 
-import           Prelude hiding (catch)
+import           Prelude 
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 706
+  hiding (catch)
+#endif
 import           Data.Monoid
 import           Data.List
 import           Control.Monad (when)


### PR DESCRIPTION
This should be a fairly minimal set of changes to make doctest compatible with GHC 7.6rc1, 7.6.1, and GHC HEAD (which shows up as 7.7.x).

Other that the raw dependency bumps, the major change is that `Prelude` no longer exports `catch`.
