### PR TITLE
Treat lines with spaces only as blank.

### DIFF
--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -160,10 +160,11 @@ getResult repl = do
       return $ stripMarker line
     else do
       result <- getResult repl
-      return $ line ++ '\n' : result
+      return $ stripSpacesOnly line ++ '\n' : result
   where
     stdout_ = hOut repl
     stripMarker l = take (length l - length marker) l
+    stripSpacesOnly line = if all isSpace line then "" else line
 
 -- | Evaluate an expresion
 eval

--- a/test/InterpreterSpec.hs
+++ b/test/InterpreterSpec.hs
@@ -73,6 +73,11 @@ spec = do
       ghci "putStrLn \"foo\" >> putStrLn \"bar\" >> putStrLn \"baz\""
         `shouldEvaluateTo` "foo\nbar\nbaz\n"
 
+    it "treats lines with spaces only as blank" $ withInterpreter $ \ghci -> do
+      ghci "putStrLn \" \"" `shouldEvaluateTo` "\n"
+      ghci "putStrLn \"foo\" >> putStrLn \"  \" >> putStrLn \"baz\""
+        `shouldEvaluateTo` "foo\n\nbaz\n"
+
     it "captures stderr" $ withInterpreter $ \ghci -> do
       ghci "import System.IO" `shouldEvaluateTo` ""
       ghci "hPutStrLn stderr \"foo\"" `shouldEvaluateTo` "foo\n"


### PR DESCRIPTION
This patch solves a problem of not having an option to match outputs consisting solely of spaces:

``` haskell
-- >>> f
-- ???
f :: IO ()
f = putStrLn " "
```

Nothing we can put in place of `???` to match `" "`. With patch, `<BLANKLINE>` will match it.
