### PR TITLE
Ability to selectively run tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /dist/
+/.cabal-sandbox
+cabal.sandbox.config

--- a/README.markdown
+++ b/README.markdown
@@ -216,7 +216,7 @@ Alternatively you can pass any GHC options to Doctest, e.g.:
 
 ### Running specific tests
 
-You can choose to run a subset of your doctests in a project by specifying one or more --dt--select flags.s
+You can choose to run a subset of your doctests in a project by specifying one or more --dt--select flags.
 
     doctest --dt-select=Foo       src/*.hs # All tests in the Foo module
     doctest --dt-select=Foo:22    src/*.hs # Doctest on line 22 of module Foo

--- a/README.markdown
+++ b/README.markdown
@@ -214,6 +214,14 @@ Alternatively you can pass any GHC options to Doctest, e.g.:
 
 [language-pragma]: http://www.haskell.org/ghc/docs/latest/html/users_guide/pragmas.html#language-pragma
 
+### Running specific tests
+
+You can choose to run a subset of your doctests in a project by specifying one or more --dt--select flags.s
+
+    doctest --dt-select=Foo       src/*.hs # All tests in the Foo module
+    doctest --dt-select=Foo:22    src/*.hs # Doctest on line 22 of module Foo
+    doctest --dt-select=Foo:22-25 src/*.hs # Doctest between lines 22 and 25 inclusive.
+
 ### Cabal integration
 
 Doctest provides both, an executable and a library.  The library exposes a

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -46,6 +46,7 @@ library
     , Run
     , Util
     , Sandbox
+    , TestSelector
   build-depends:
       base          == 4.*
     , ghc           >= 7.0 && < 7.8
@@ -61,7 +62,7 @@ executable doctest
   main-is:
       Main.hs
   ghc-options:
-      -Wall -threaded
+      -Wall 
   hs-source-dirs:
       driver
   build-depends:

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -62,7 +62,7 @@ executable doctest
   main-is:
       Main.hs
   ghc-options:
-      -Wall 
+      -Wall -threaded
   hs-source-dirs:
       driver
   build-depends:

--- a/src/Help.hs
+++ b/src/Help.hs
@@ -11,13 +11,17 @@ import           Interpreter (ghc)
 usage :: String
 usage = unlines [
           "Usage:"
-        , "  doctest [ GHC OPTION | MODULE ]..."
+        , "  doctest [ --dt-select=<Module>:<lineStart>[-lineEnd] | GHC OPTION | MODULE ]..."
         , "  doctest --help"
         , "  doctest --version"
         , ""
         , "Options:"
-        , "  --help     display this help and exit"
-        , "  --version  output version information and exit"
+        , "  --help      display this help and exit"
+        , "  --version   output version information and exit"
+        , "  --dt-select=<Module>:<firstLine>[-lastLine] "
+        , "              Selectively run doctests based on Module and line"
+        , "              numbers. Can specify more than one of this option."
+        , "              e.g: --dt-select=Foo:13 --dt-select=Bar:13-15"
         ]
 
 printVersion :: IO ()

--- a/src/Help.hs
+++ b/src/Help.hs
@@ -18,10 +18,12 @@ usage = unlines [
         , "Options:"
         , "  --help      display this help and exit"
         , "  --version   output version information and exit"
-        , "  --dt-select=<Module>:<firstLine>[-lastLine] "
+        , "  --dt-select=<Module>:[<firstLine>[-lastLine]]"
         , "              Selectively run doctests based on Module and line"
         , "              numbers. Can specify more than one of this option."
-        , "              e.g: --dt-select=Foo:13 --dt-select=Bar:13-15"
+        , "              e.g: --dt-select=Foo       All tests in Foo"
+        , "                   --dt-select=Foo:13    Foo line 13 " 
+        , "                   --dt-select=Bar:13-15 Foo lines 13-15"
         ]
 
 printVersion :: IO ()

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -104,7 +104,7 @@ doctest_ :: [TestSelector] -> [String] -> IO Summary
 doctest_ testSelectors args = do
 
   -- get examples from Haddock comments
-  modules <- (filterModules testSelectors) <$> getDocTests args
+  modules <- filterModules testSelectors <$> getDocTests args
 
   Interpreter.withInterpreter args $ \repl -> do
     runModules repl modules

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -22,6 +22,11 @@ import           Parse
 import           Help
 import           Runner
 import qualified Interpreter
+import           TestSelector 
+                 ( extractTestSelectors
+                 , filterModules
+                 , Args (Args)
+                 , TestSelector )
 
 ghcPackageDbFlag :: String
 #if __GLASGOW_HASKELL__ >= 706
@@ -58,18 +63,25 @@ doctest args
         hPutStrLn stderr "WARNING: GHC does not support --interactive, skipping tests"
         exitSuccess
 
-      let (f, args_) = stripOptGhc args
-      when f $ do
-        hPutStrLn stderr "WARNING: --optghc is deprecated, doctest now accepts arbitrary GHC options\ndirectly."
-        hFlush stderr
-      r <- doctest_ (addPackageConf args_) `E.catch` \e -> do
-        case fromException e of
-          Just (UsageError err) -> do
-            hPutStrLn stderr ("doctest: " ++ err)
-            hPutStrLn stderr "Try `doctest --help' for more information."
-            exitFailure
-          _ -> E.throwIO e
-      when (not $ isSuccess r) exitFailure
+      either  
+        (usageError . show)
+        (\ (Args selectors ghcArgs) -> do
+          let (f  , args_) = stripOptGhc ghcArgs
+
+          when f $ do
+            hPutStrLn stderr "WARNING: --optghc is deprecated, doctest now accepts arbitrary GHC options\ndirectly."
+            hFlush stderr
+          r <- doctest_ selectors (addPackageConf args_) `E.catch` \e -> do
+            case fromException e of
+              Just (UsageError err) -> usageError err
+              _ -> E.throwIO e
+          when (not $ isSuccess r) exitFailure)
+       (extractTestSelectors args)
+    where
+      usageError err = do
+        hPutStrLn stderr ("doctest: " ++ err)
+        hPutStrLn stderr "Try `doctest --help' for more information."
+        exitFailure
 
 isSuccess :: Summary -> Bool
 isSuccess s = sErrors s == 0 && sFailures s == 0
@@ -88,11 +100,11 @@ stripOptGhc = go
       "--optghc" : opt : rest -> (True, opt : snd (go rest))
       opt : rest              -> maybe (fmap (opt :)) (\x (_, xs) -> (True, x :xs)) (stripPrefix "--optghc=" opt) (go rest)
 
-doctest_ :: [String] -> IO Summary
-doctest_ args = do
+doctest_ :: [TestSelector] -> [String] -> IO Summary
+doctest_ testSelectors args = do
 
   -- get examples from Haddock comments
-  modules <- getDocTests args
+  modules <- (filterModules testSelectors) <$> getDocTests args
 
   Interpreter.withInterpreter args $ \repl -> do
     runModules repl modules

--- a/src/TestSelector.hs
+++ b/src/TestSelector.hs
@@ -1,0 +1,112 @@
+module TestSelector 
+  (extractTestSelectors
+  , filterModuleContent
+  , filterModules
+  , TestSelector (..)
+  , Args (..)
+  , ArgParserError (..)
+  ) where
+
+import           Extract (Module,moduleName,moduleContent) 
+import           Location 
+                 (Located (Located)
+                 , Location (Location,UnhelpfulLocation))  
+import           Parse (DocTest)
+import           Data.List (partition,isPrefixOf,stripPrefix,filter,null)
+import           Data.Monoid (Monoid (mempty,mappend))
+import           Control.Applicative ((<$>),(<*>),pure)
+import           Data.Either (Either,either)
+import           Control.Monad.Trans.State 
+                 ( StateT (StateT)
+                 , get
+                 , modify
+                 , evalStateT
+                 , runStateT )
+import           Data.Tuple (swap)
+import           Data.Maybe (maybe)
+import           Data.Char (isDigit)
+
+type GhcArg = String
+data Args = Args [TestSelector] [GhcArg] deriving (Show,Eq)
+
+instance Monoid Args where 
+  mappend (Args ats aghc) (Args bts bghc) = Args (ats ++ bts) (aghc ++ bghc)
+  mempty = Args [] []
+
+data TestSelector = TestSelector {
+  selectModule :: String 
+  , lineStart :: Int 
+  , lineEnd :: Maybe Int
+  } deriving (Show,Eq)
+
+data ArgParserError = ArgParserError { 
+  expected :: String,
+  remainingText :: String
+  } deriving (Eq)
+
+instance Show ArgParserError where
+  show (ArgParserError e remain) = 
+    "Error parsing " ++ prefix ++ " arg. Expected " ++ e ++ " at " ++ remain
+
+type ArgParserEither = Either ArgParserError
+type ArgParser a = StateT String ArgParserEither a
+
+extractTestSelectors :: [String] -> ArgParserEither Args
+extractTestSelectors = foldl accumSelector $ Right mempty
+  where     
+    accumSelector :: ArgParserEither Args -> String -> ArgParserEither Args
+    accumSelector a arg = 
+      mappend <$> a <*> if isPrefixOf prefix arg 
+                        then fmap (\ts -> Args [ts] []) $ parseTestSelector arg
+                        else pure $ Args [] [arg]
+    parseTestSelector :: String -> ArgParserEither TestSelector
+    parseTestSelector s = (flip evalStateT) s $ do
+      expectText prefix
+      modName  <- spanParse (/= ':') "Module name"
+      parseDrop 1 
+      ls <- read <$> spanParse isDigit "Line number"
+      le <- tryParse parseLineEnd
+      return $ TestSelector modName ls le
+
+    parseLineEnd = do
+      expectText "-" 
+      read <$> spanParse isDigit "Line number"
+
+    parseDrop n = modify (drop n)
+
+    expectText :: String -> ArgParser () 
+    expectText t = StateT $ \s ->
+      maybe 
+        (Left $ ArgParserError t s) 
+        (\rest -> Right ((),rest)) 
+        (stripPrefix t s)
+
+    spanParse :: (Char -> Bool) -> String -> ArgParser String
+    spanParse f desc = StateT $ \s -> 
+      case span f s of
+        ([],rest) -> (Left . ArgParserError desc) rest
+        t         -> Right t 
+
+    tryParse :: ArgParser a -> ArgParser (Maybe a)
+    tryParse p = StateT $ \s -> Right $
+      either 
+        (const (Nothing,s)) 
+        (\(a,s') -> (Just a , s')) 
+        (runStateT p s)
+
+prefix :: String    
+prefix = "--dt-select="
+
+filterModules :: [TestSelector] -> [Module [Located DocTest]] -> [Module [Located DocTest]]
+filterModules ss = filter (not . null . moduleContent) . map (filterModuleContent ss)
+
+filterModuleContent :: [TestSelector] -> Module [Located DocTest] -> Module [Located DocTest] 
+filterModuleContent [] m = m
+filterModuleContent ss m = filterLines $ filter ((moduleName m ==) . selectModule ) ss
+  where 
+    filterLines ss' = m { moduleContent = filter (not . null) $ map (filter $ filterDocTest ss') $ moduleContent m }
+    filterDocTest :: [TestSelector] -> Located DocTest -> Bool
+    filterDocTest _ (Located (UnhelpfulLocation _) _) = False
+    filterDocTest ss' (Located (Location _ line) _) = 
+      any (\s -> line == lineStart s ) ss'
+

--- a/src/TestSelector.hs
+++ b/src/TestSelector.hs
@@ -12,10 +12,10 @@ import           Location
                  (Located (Located)
                  , Location (Location,UnhelpfulLocation))  
 import           Parse (DocTest)
-import           Data.List (partition,isPrefixOf,stripPrefix,filter,null)
+import           Data.List (isPrefixOf,stripPrefix)
 import           Data.Monoid (Monoid (mempty,mappend))
 import           Control.Applicative ((<$>),(<*>),pure)
-import           Data.Either (Either,either)
+--import           Data.Either (Either,either)
 import           Control.Monad.Trans.State 
                  ( StateT (StateT)
                  , get

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -23,7 +23,7 @@ doctest :: FilePath   -- ^ current directory of `doctest` process
         -> Summary    -- ^ expected test result
         -> Assertion
 doctest workingDir args summary = do
-  r <- withCurrentDirectory ("test/integration" </> workingDir) (hSilence [stderr] $ doctest_ args)
+  r <- withCurrentDirectory ("test/integration" </> workingDir) (hSilence [stderr] $ doctest_ [] args )
   assertEqual label summary r
   where
     label = workingDir ++ " " ++ show args

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -98,7 +98,7 @@ spec = do
 
   describe "doctest_" $ do
     context "on parse error" $ do
-      let action = withCurrentDirectory "test/integration/parse-error" (doctest_ ["Foo.hs"])
+      let action = withCurrentDirectory "test/integration/parse-error" (doctest_ [] ["Foo.hs"])
 
       it "aborts with (ExitFailure 1)" $ do
         hSilence [stderr] action `shouldThrow` (== ExitFailure 1)

--- a/test/TestSelectorSpec.hs
+++ b/test/TestSelectorSpec.hs
@@ -1,7 +1,7 @@
 module TestSelectorSpec (main, spec) where
 
 import           Test.Hspec
-import           Orphans
+import           Orphans ()
 import           TestSelector
 import           Extract (Module (Module))
 import           Location 
@@ -15,37 +15,46 @@ spec :: Spec
 spec = do
 
   describe "extractTestSelectors" $ do
-    it "should return all args when no --dt-select= options" $ do
+    it "should return all args when no --dt-select= options" $ 
       extractTestSelectors ["foo","bar"] `shouldBe` (Right $ Args [] ["foo","bar"])
-    it "should return a selector and leave other args alone" $ do
+      
+    it "should return a selector and leave other args alone" $ 
       extractTestSelectors 
         [ "--dt-select=foo:21" ,"bar"] 
         `shouldBe` 
         (Right $ Args [TestSelector "foo" 21 Nothing] ["bar"])      
-    it "should return a selector with start and end line num" $ do
+        
+    it "should return a selector with start and end line num" $ 
       extractTestSelectors 
         [ "--dt-select=foo:21-23"] 
         `shouldBe` 
         (Right $ Args [TestSelector "foo" 21 (Just 23)] [])              
         
-  describe "filterModuleTests" $ do
+  describe "filterModuleContent" $ do
     let loc1 = Located (Location "" 13) (Property " ")
         loc2 = Located (Location "" 22) (Property " ")
-        testModule = Module "foo" Nothing [[loc1,loc2]]
-        
-    it "should filter nothing with no selectors" $ do
+        loc3 = Located (Location "" 24) (Property " ")
+        loc4 = Located (UnhelpfulLocation "") (Property " ")
+        testModule = Module "foo" Nothing [[loc1,loc2,loc3,loc4]]
+
+    it "should filter nothing with no selectors" $
       filterModuleContent [] testModule `shouldBe` testModule 
 
-    it "should filter everything with a selector that doesn't apply" $ do
-      (filterModuleContent [TestSelector "bar" 22 Nothing] testModule)
+    it "should filter everything with a selector that doesn't apply" $ 
+      filterModuleContent [TestSelector "bar" 22 Nothing] testModule
       `shouldBe` 
       testModule { moduleContent = [] }       
       
-    it "should keep the stuff that is selected" $ do
-      (filterModuleContent [TestSelector "foo" 22 Nothing] testModule)
+    it "should keep the stuff that is selected" $ 
+      filterModuleContent [TestSelector "foo" 22 Nothing] testModule
       `shouldBe` 
       testModule { moduleContent = [[loc2]] }
       
+    it "should filter a range" $
+      filterModuleContent [TestSelector "foo" 13 (Just 22)] testModule
+      `shouldBe`
+      testModule { moduleContent = [[loc1,loc2]] }
+
   describe "filterModules" $ do 
     let loc1 = Located (Location "" 13) (Property " ")
         loc2 = Located (Location "" 22) (Property " ")
@@ -53,8 +62,28 @@ spec = do
         testModule2 = Module "bar" Nothing [[loc1,loc2]]
         testModules = [testModule1,testModule2]
 
-    it "should filter stuff" $ do 
+    it "shouldn't filter anything if there are no filters at all" $ 
+      filterModules [] testModules `shouldBe` testModules
+
+    it "should filter stuff" $  
       filterModules [TestSelector "foo" 22 Nothing] testModules
       `shouldBe`
-      ([testModule1 {moduleContent = [[loc2]] }])
+      [testModule1 {moduleContent = [[loc2]] }]
+      
+    it "should filter fine with two selectors" $  
+      filterModules [
+        TestSelector "foo" 22 Nothing
+        , TestSelector "bar" 13 Nothing]  testModules
+      `shouldBe`
+      [testModule1 {moduleContent = [[loc2]] }
+      , testModule2 {moduleContent = [[loc1]] } ]
 
+    it "should filter a range" $
+      filterModules [ TestSelector "foo" 13 (Just 22) ] testModules
+      `shouldBe`
+      [testModule1]
+
+    it "should remove modules which become empty" $ 
+      filterModules [TestSelector "foo" 22 Nothing] testModules
+      `shouldBe`
+      [testModule1 {moduleContent = [[loc2]]}]     

--- a/test/TestSelectorSpec.hs
+++ b/test/TestSelectorSpec.hs
@@ -1,0 +1,60 @@
+module TestSelectorSpec (main, spec) where
+
+import           Test.Hspec
+import           Orphans
+import           TestSelector
+import           Extract (Module (Module))
+import           Location 
+                 ( Located (Located)
+                 ,Location (Location,UnhelpfulLocation))
+import           Parse (DocTest (Property),moduleContent)
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+
+  describe "extractTestSelectors" $ do
+    it "should return all args when no --dt-select= options" $ do
+      extractTestSelectors ["foo","bar"] `shouldBe` (Right $ Args [] ["foo","bar"])
+    it "should return a selector and leave other args alone" $ do
+      extractTestSelectors 
+        [ "--dt-select=foo:21" ,"bar"] 
+        `shouldBe` 
+        (Right $ Args [TestSelector "foo" 21 Nothing] ["bar"])      
+    it "should return a selector with start and end line num" $ do
+      extractTestSelectors 
+        [ "--dt-select=foo:21-23"] 
+        `shouldBe` 
+        (Right $ Args [TestSelector "foo" 21 (Just 23)] [])              
+        
+  describe "filterModuleTests" $ do
+    let loc1 = Located (Location "" 13) (Property " ")
+        loc2 = Located (Location "" 22) (Property " ")
+        testModule = Module "foo" Nothing [[loc1,loc2]]
+        
+    it "should filter nothing with no selectors" $ do
+      filterModuleContent [] testModule `shouldBe` testModule 
+
+    it "should filter everything with a selector that doesn't apply" $ do
+      (filterModuleContent [TestSelector "bar" 22 Nothing] testModule)
+      `shouldBe` 
+      testModule { moduleContent = [] }       
+      
+    it "should keep the stuff that is selected" $ do
+      (filterModuleContent [TestSelector "foo" 22 Nothing] testModule)
+      `shouldBe` 
+      testModule { moduleContent = [[loc2]] }
+      
+  describe "filterModules" $ do 
+    let loc1 = Located (Location "" 13) (Property " ")
+        loc2 = Located (Location "" 22) (Property " ")
+        testModule1 = Module "foo" Nothing [[loc1,loc2]]
+        testModule2 = Module "bar" Nothing [[loc1,loc2]]
+        testModules = [testModule1,testModule2]
+
+    it "should filter stuff" $ do 
+      filterModules [TestSelector "foo" 22 Nothing] testModules
+      `shouldBe`
+      ([testModule1 {moduleContent = [[loc2]] }])
+


### PR DESCRIPTION
I've made a smallish tweak to doctest to give the user the ability to be able to only run the doctests that they want. 

It's only by modules and line numbers, so it is not perfect, but it was the simplest change to some kind of selectivity in (that I could think of, anyway).

```
doctest --dt-select=Foo       src/*.hs # All tests in the Foo module
doctest --dt-select=Foo:22    src/*.hs # Doctest on line 22 of module Foo
doctest --dt-select=Foo:22-25 src/*.hs # Doctest between lines 22 and 25 inclusive.
```

I'm not attached to the implementation (esp. how I avoided pulling in some parsing deps for the arg parsing) so if you like the idea and want me to change it before merging it, just let me know. 
