### PR TITLE
Bunch of README fixes, and addition of the "Multi-line output" section

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -273,7 +273,7 @@ There are three ways to deal with this:
     -- >>> xpto "what?"
     -- "what?:xpto!"
     xpto :: Text -> Text
-    xpto = (<> ":xtpo!")
+    xpto = (<> ":xpto!")
     ```
 
 3.  Putting it into a ```$setup``` hook


### PR DESCRIPTION
I think each commit should be self-explanatory! I left the broken example broken, since it's broken. But it should be expecting "6" as output like in the working example.
