### PR TITLE
Support HASKELL_PACKAGE_SANDBOXES

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -38,6 +38,7 @@ library
     , Interpreter
     , Location
     , Help
+    , PackageDBs
     , Parse
     , Paths_doctest
     , Property

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -38,7 +38,7 @@ import           GhcUtil (withGhc)
 import           Location hiding (unLoc)
 
 import           Util (convertDosLineEndings)
-import           Sandbox (getSandboxArguments)
+import           PackageDBs (getPackageDBArgs)
 
 -- | A wrapper around `SomeException`, to allow for a custom `Show` instance.
 newtype ExtractError = ExtractError SomeException
@@ -146,8 +146,8 @@ parse args = withGhc args $ \modules_ -> withTempOutputDir $ do
 -- those modules (possibly indirect).
 extract :: [String] -> IO [Module (Located String)]
 extract args = do
-  sandboxArgs <- getSandboxArguments
-  let args'  = args ++ sandboxArgs
+  packageDBArgs <- getPackageDBArgs
+  let args'  = args ++ packageDBArgs
   mods <- parse args'
   let docs = map (fmap (fmap convertDosLineEndings) . extractFromModule . tm_parsed_module) mods
 

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -19,7 +19,6 @@ import           Data.Char
 import           GHC.Paths (ghc)
 
 import           Language.Haskell.GhciWrapper
-import           Sandbox (getSandboxArguments)
 
 haveInterpreterKey :: String
 haveInterpreterKey = "Have interpreter"
@@ -48,8 +47,7 @@ withInterpreter
   -> (Interpreter -> IO a)  -- ^ Action to run
   -> IO a                   -- ^ Result of action
 withInterpreter flags action = do
-  sandboxFlags <- getSandboxArguments
-  let args = sandboxFlags ++ ["--interactive"] ++ flags
+  let args = ["--interactive"] ++ flags
   bracket (new defaultConfig{configGhci = ghc} args) close action
 
 -- | Evaluate an expression; return a Left value on exceptions.

--- a/src/PackageDBs.hs
+++ b/src/PackageDBs.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternGuards #-}
+-- | Manage GHC package databases
+module PackageDBs
+    ( PackageDBs (..)
+    , ArgStyle (..)
+    , dbArgs
+    , buildArgStyle
+    , getPackageDBsFromEnv
+    , getPackageDBArgs
+    ) where
+
+import System.Environment (getEnvironment)
+import System.FilePath (splitSearchPath, searchPathSeparator)
+import qualified Sandbox
+import Control.Exception (try, SomeException)
+import System.Directory (getCurrentDirectory)
+
+-- | Full stack of GHC package databases
+data PackageDBs = PackageDBs
+    { includeUser :: Bool
+    -- | Unsupported on GHC < 7.6
+    , includeGlobal :: Bool
+    , extraDBs :: [FilePath]
+    }
+    deriving (Show, Eq)
+
+-- | Package database handling switched between GHC 7.4 and 7.6
+data ArgStyle = Pre76 | Post76
+    deriving (Show, Eq)
+
+-- | Determine command line arguments to be passed to GHC to set databases correctly
+--
+-- >>> dbArgs Post76 (PackageDBs False True [])
+-- ["-no-user-package-db"]
+--
+-- >>> dbArgs Pre76 (PackageDBs True True ["somedb"])
+-- ["-package-conf","somedb"]
+dbArgs :: ArgStyle -> PackageDBs -> [String]
+dbArgs Post76 (PackageDBs user global extras) =
+    (if user then id else ("-no-user-package-db":)) $
+    (if global then id else ("-no-global-package-db":)) $
+    concatMap (\extra -> ["-package-db", extra]) extras
+dbArgs Pre76 (PackageDBs _ False _) =
+    error "Global package database must be included with GHC < 7.6"
+dbArgs Pre76 (PackageDBs user True extras) =
+    (if user then id else ("-no-user-package-conf":)) $
+    concatMap (\extra -> ["-package-conf", extra]) extras
+
+-- | The argument style to be used with the current GHC version
+buildArgStyle :: ArgStyle
+#if __GLASGOW_HASKELL__ >= 706
+buildArgStyle = Post76
+#else
+buildArgStyle = Pre76
+#endif
+
+-- | Determine the PackageDBs based on the environment and cabal sandbox
+-- information
+getPackageDBsFromEnv :: IO PackageDBs
+getPackageDBsFromEnv = do
+    env <- getEnvironment
+    case () of
+        ()
+            | Just sandboxes <- lookup "HASKELL_PACKAGE_SANDBOXES" env
+                -> return $ fromEnvMulti sandboxes
+            | Just extra <- lookup "HASKELL_PACKAGE_SANDBOX" env
+                -> return PackageDBs
+                    { includeUser = True
+                    , includeGlobal = True
+                    , extraDBs = [extra]
+                    }
+            | Just sandboxes <- lookup "GHC_PACKAGE_PATH" env
+                -> return $ fromEnvMulti sandboxes
+            | otherwise -> do
+                eres <- try $ getCurrentDirectory
+                          >>= Sandbox.getSandboxConfigFile
+                          >>= Sandbox.getPackageDbDir
+                return $ case eres :: Either SomeException FilePath of
+                    Left _ -> PackageDBs True True []
+                    Right db -> PackageDBs False True [db]
+  where
+    fromEnvMulti s = PackageDBs
+        { includeUser = False
+        , includeGlobal = global
+        , extraDBs = splitSearchPath s'
+        }
+      where
+        (s', global) =
+            case reverse s of
+                c:rest | c == searchPathSeparator -> (reverse rest, True)
+                _ -> (s, False)
+
+-- | Get the package DB flags for the current GHC version and from the
+-- environment.
+getPackageDBArgs :: IO [String]
+getPackageDBArgs = do
+      dbs <- getPackageDBsFromEnv
+      return $ dbArgs buildArgStyle dbs

--- a/src/Sandbox.hs
+++ b/src/Sandbox.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE BangPatterns #-}
 
-module Sandbox (getSandboxArguments, getPackageDbDir) where
+module Sandbox
+    ( getSandboxArguments
+    , getPackageDbDir
+    , getSandboxConfigFile
+    ) where
 
 import Control.Applicative ((<$>))
 import Control.Exception as E (catch, SomeException, throwIO)

--- a/test/PackageDBsSpec.hs
+++ b/test/PackageDBsSpec.hs
@@ -1,0 +1,69 @@
+module PackageDBsSpec (main, spec) where
+
+import qualified Control.Exception         as E
+import           Data.List                 (intercalate)
+import           PackageDBs
+import           System.Directory          (getCurrentDirectory,
+                                            removeDirectoryRecursive,
+                                            setCurrentDirectory)
+import           System.Environment.Compat
+import           System.FilePath           (searchPathSeparator)
+import           Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+withCurrentDirectory :: FilePath -> IO a -> IO a
+withCurrentDirectory workingDir action = do
+  E.bracket getCurrentDirectory setCurrentDirectory $ \_ -> do
+    setCurrentDirectory workingDir
+    action
+
+withEnv :: String -> String -> IO a -> IO a
+withEnv k v action = E.bracket save restore $ \_ -> do
+  setEnv k v >> action
+  where
+    save    = lookup k <$> getEnvironment
+    restore = maybe (unsetEnv k) (setEnv k)
+
+clearEnv :: IO a -> IO a
+clearEnv = withEnv "GHC_PACKAGE_PATH" ""
+         . withEnv "HASKELL_PACKAGE_SANDBOX" ""
+         . withEnv "HASKELL_PACKAGE_SANDBOXES" ""
+
+combineDirs :: [FilePath] -> String
+combineDirs = intercalate [searchPathSeparator]
+
+spec :: Spec
+spec = do
+  describe "getPackageDBsFromEnv" $ do
+    it "uses global and user when no env or sandboxing used" $
+      withCurrentDirectory "test" $ clearEnv $ do
+        dbs <- getPackageDBsFromEnv
+        dbs `shouldBe` PackageDBs True True []
+    it "respects GHC_PACKAGE_PATH" $
+      withCurrentDirectory "test" $ clearEnv $
+      withEnv "GHC_PACKAGE_PATH" (combineDirs ["foo", "bar", ""]) $ do
+        dbs <- getPackageDBsFromEnv
+        dbs `shouldBe` PackageDBs False True ["foo", "bar"]
+    it "HASKELL_PACKAGE_SANDBOXES trumps GHC_PACKAGE_PATH" $
+      withCurrentDirectory "test" $ clearEnv $
+      withEnv "GHC_PACKAGE_PATH" (combineDirs ["foo1", "bar1", ""]) $
+      withEnv "HASKELL_PACKAGE_SANDBOXES" (combineDirs ["foo2", "bar2", ""]) $ do
+        dbs <- getPackageDBsFromEnv
+        dbs `shouldBe` PackageDBs False True ["foo2", "bar2"]
+    it "HASKELL_PACKAGE_SANDBOX trumps GHC_PACKAGE_PATH" $
+      withCurrentDirectory "test" $ clearEnv $
+      withEnv "GHC_PACKAGE_PATH" (combineDirs ["foo1", "bar1", ""]) $
+      withEnv "HASKELL_PACKAGE_SANDBOX" (combineDirs ["foo2"]) $ do
+        dbs <- getPackageDBsFromEnv
+        dbs `shouldBe` PackageDBs True True ["foo2"]
+    it "respects cabal sandboxes" $
+      withCurrentDirectory "test/sandbox" $ clearEnv $ do
+        dbs <- getPackageDBsFromEnv
+        dbs `shouldBe` PackageDBs False True ["/home/me/doctest-haskell/.cabal-sandbox/i386-osx-ghc-7.6.3-packages.conf.d"]
+    it "env trumps cabal sandboxes" $
+      withCurrentDirectory "test/sandbox" $ clearEnv $
+      withEnv "GHC_PACKAGE_PATH" (combineDirs ["foo", "bar"]) $ do
+        dbs <- getPackageDBsFromEnv
+        dbs `shouldBe` PackageDBs False False ["foo", "bar"]

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -94,29 +94,6 @@ spec = do
         rmDir "test/integration/custom-package-conf/packages/"
         rmDir "test/integration/custom-package-conf/foo/dist/"
 
-    it "respects HASKELL_PACKAGE_SANDBOXES" $ do
-      withCurrentDirectory "test/integration/custom-package-conf/foo" $ do
-        ExitSuccess <- rawSystem "ghc-pkg" ["init", "../packages"]
-        ExitSuccess <- rawSystem "ghc-pkg" ["init", "../packages-extra"]
-        ExitSuccess <- rawSystem "cabal" ["configure", "--disable-optimization", "--disable-library-profiling", "--package-db=../packages"]
-        ExitSuccess <- rawSystem "cabal" ["build"]
-        ExitSuccess <- rawSystem "cabal" ["register", "--inplace"]
-        return ()
-
-      let sandboxes = intercalate [searchPathSeparator]
-            [ "test/integration/custom-package-conf/packages-extra"
-            , "test/integration/custom-package-conf/packages"
-            , ""
-            ]
-      withEnv "HASKELL_PACKAGE_SANDBOXES" sandboxes $ do
-        hCapture_ [stderr] (doctest ["test/integration/custom-package-conf/Bar.hs"])
-          `shouldReturn` "Examples: 2  Tried: 2  Errors: 0  Failures: 0\n"
-
-      `E.finally` do
-        rmDir "test/integration/custom-package-conf/packages/"
-        rmDir "test/integration/custom-package-conf/packages-extra/"
-        rmDir "test/integration/custom-package-conf/foo/dist/"
-
   describe "doctest_" $ do
     context "on parse error" $ do
       let action = withCurrentDirectory "test/integration/parse-error" (doctest_ ["Foo.hs"])

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -106,6 +106,7 @@ spec = do
       let sandboxes = intercalate [searchPathSeparator]
             [ "test/integration/custom-package-conf/packages-extra"
             , "test/integration/custom-package-conf/packages"
+            , ""
             ]
       withEnv "HASKELL_PACKAGE_SANDBOXES" sandboxes $ do
         hCapture_ [stderr] (doctest ["test/integration/custom-package-conf/Bar.hs"])

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -11,4 +11,5 @@ main = doctest [
   , "-optP-include"
   , "-optPdist/build/autogen/cabal_macros.h"
   , "src/Run.hs"
+  , "src/PackageDBs.hs"
   ]


### PR DESCRIPTION
This is to address a use case we have in stack for multiple custom
package databases, which is not currently supported by the single
sandbox environment variable.