### PR TITLE
Make it easier to use doctest in projects

### DIFF
--- a/src/Run.hs
+++ b/src/Run.hs
@@ -6,13 +6,18 @@ module Run (
 , doctest_
 , Summary
 , stripOptGhc
+, expandDirs
 #endif
 ) where
 
 import           Data.List
+import           Control.Applicative ((<$>))
 import           Control.Monad (when, unless)
+import           System.Directory (doesFileExist, doesDirectoryExist,
+                                   getDirectoryContents)
 import           System.Environment (getEnvironment)
 import           System.Exit (exitFailure, exitSuccess)
+import           System.FilePath ((</>), takeExtension)
 import           System.IO
 
 import qualified Control.Exception as E
@@ -33,11 +38,15 @@ import qualified Interpreter
 --
 -- This can be used to create a Cabal test suite that runs doctest for your
 -- project.
+--
+-- If a directory is given, it is traversed to find all .hs and .lhs files
+-- inside of it, ignoring hidden entries.
 doctest :: [String] -> IO ()
-doctest args
-  | "--help"    `elem` args = putStr usage
-  | "--version" `elem` args = printVersion
+doctest args0
+  | "--help"    `elem` args0 = putStr usage
+  | "--version" `elem` args0 = printVersion
   | otherwise = do
+      args <- concat <$> mapM expandDirs args0
       i <- Interpreter.interpreterSupported
       unless i $ do
         hPutStrLn stderr "WARNING: GHC does not support --interactive, skipping tests"
@@ -60,6 +69,32 @@ doctest args
           _ -> E.throwIO e
       when (not $ isSuccess r) exitFailure
 
+-- | Expand a reference to a directory to all .hs and .lhs files within it.
+expandDirs :: String -> IO [String]
+expandDirs fp = do
+    isDir <- doesDirectoryExist fp
+    if isDir
+        then findHaskellFiles fp
+        else return [fp]
+  where
+    findHaskellFiles dir = do
+        contents <- getDirectoryContents dir
+        concat <$> mapM go (filter (not . hidden) contents)
+      where
+        go name = do
+            isDir <- doesDirectoryExist fp
+            if isDir
+                then findHaskellFiles fp
+                else if isHaskellFile fp
+                        then return [fp]
+                        else return []
+          where
+            fp = dir </> name
+
+    hidden ('.':_) = True
+    hidden _ = False
+
+    isHaskellFile fp = takeExtension fp `elem` [".hs", ".lhs"]
 
 -- | Same as @doctest@, but sets relevant flags for Cabal projects for
 -- cabal_macros.h and the autogen directory.

--- a/src/Test/DocTest.hs
+++ b/src/Test/DocTest.hs
@@ -1,5 +1,6 @@
 module Test.DocTest (
   doctest
+ ,doctestDist
 ) where
 
 import           Run

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -120,3 +120,18 @@ spec = do
     it "indicates when nothing got striped" $
       property $ \xs ->
         stripOptGhc xs == (False, xs)
+
+  describe "expandDirs" $ do
+    it "expands a directory" $ do
+      res <- expandDirs "example"
+      sort res `shouldBe`
+        [ "example/src/Example.hs"
+        , "example/test/doctests.hs"
+        ]
+    it "ignores files" $ do
+      res <- expandDirs "doctest.cabal"
+      res `shouldBe` ["doctest.cabal"]
+    it "ignores random things" $ do
+      let x = "foo bar baz bin"
+      res <- expandDirs x
+      res `shouldBe` [x]


### PR DESCRIPTION
This adds two changes which I think will make doctest much easier to integrate (pinging @bitemyapp, who inspired this):

1. The `doctestDist` function automatically adds cabal_macros.h and the autogen files (Paths mainly), useful for Cabal projects. It's done in a way that is compatible with both stack and cabal-install (not sure about cabal sandboxes, though).
2. Add the ability to specify directories in addition to files. If a directory is given, `doctest` will now traverse it to find all `.hs` and `.lhs` files.

Not sure if either or both of these are wanted, but it would make life easier for me in other projects.