### PR TITLE
Add --cpp option to support MIN_VERSION-macro

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -59,6 +59,9 @@ library
     , process
     , ghc-paths     >= 0.1.0.9
     , transformers
+    , find-conduit
+    , conduit
+    , resourcet
 
 executable doctest
   main-is:
@@ -70,6 +73,9 @@ executable doctest
   build-depends:
       base          == 4.*
     , doctest
+    , find-conduit
+    , conduit
+    , resourcet
 
 test-suite spec
   main-is:
@@ -102,6 +108,9 @@ test-suite spec
     , stringbuilder >= 0.4
     , silently      >= 1.2.4
     , setenv
+    , find-conduit
+    , conduit
+    , resourcet
 
 test-suite doctests
   main-is:
@@ -115,3 +124,6 @@ test-suite doctests
   build-depends:
       base
     , doctest
+    , find-conduit
+    , conduit
+    , resourcet

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -3,13 +3,11 @@ module Main where
 import           Test.DocTest
 
 main :: IO ()
-main = doctest [
-    "-packageghc"
+main = doctest $ [
+    "--cpp"
+  , "-packageghc"
   , "-isrc"
   , "-ighci-wrapper/src"
-  , "-idist/build/autogen/"
-  , "-optP-include"
-  , "-optPdist/build/autogen/cabal_macros.h"
   , "src/Run.hs"
   , "src/PackageDBs.hs"
   ]


### PR DESCRIPTION
Hi,

I read https://github.com/sol/doctest/issues/103
This solution is difficult for beginner.
When we use stack, ```dist``` path is changed and the solution does not work.
I add ```---cpp``` option which searchs a directory of macro-header and makes command-arguments for cpp.

