### PR TITLE
[RFC] Terminate ghci process before waiting for it.

### DIFF
--- a/ghci-wrapper/src/Language/Haskell/GhciWrapper.hs
+++ b/ghci-wrapper/src/Language/Haskell/GhciWrapper.hs
@@ -88,6 +88,7 @@ close repl = do
   -- around consuming 100% CPU.  This happens when ghci tries to print
   -- something to stdout in its signal handler (e.g. when it is blocked in
   -- threadDelay it writes "Interrupted." on SIGINT).
+  terminateProcess $ process repl
   e <- waitForProcess $ process repl
   hClose $ hOut repl
 


### PR DESCRIPTION
May be related to https://github.com/hspec/sensei/issues/30.

This change is based on the unconfirmed theory that pressing ^C repeatedly sometimes leaves ghci processes running, with the same symptoms as described in the comment near this change.

Breaks the test suite, but it does have the expected and desired effect that the reaction on ^C is immediate.

Before I look at the test suite: is this worth investigating?

thanks-