### PR TITLE
fix tests when config-value is present in system

### DIFF
--- a/src/Help.hs
+++ b/src/Help.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PackageImports #-}
 module Help (
   usage
 , printVersion
@@ -5,7 +6,7 @@ module Help (
 
 import           Paths_doctest (version)
 import           Data.Version (showVersion)
-import           Config as GHC
+import "ghc"     Config as GHC
 import           Interpreter (ghc)
 
 usage :: String


### PR DESCRIPTION
ghci fails to disambiguate 'Config' in this case as:

  src/Help.hs:8:18:
    Ambiguous module name ‘Config’:
      it was found in multiple packages:
      config-value-0.4.0.1@confi_JzUyuyr9gPE2bcxdUwNhUS ghc-7.10.3

Fixed by explicitly importing moduls from 'ghc' package.

Signed-off-by: Sergei Trofimovich siarheit@google.com
