### PR TITLE
Print doctest output in a UTF-8-compatible codepage on Windows

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -53,6 +53,7 @@ library
     , base-compat   >= 0.4.2
     , ghc           >= 7.0 && < 8.2
     , syb           >= 0.3
+    , code-page     >= 0.1
     , deepseq
     , directory
     , filepath
@@ -88,6 +89,7 @@ test-suite spec
       base
     , ghc
     , syb
+    , code-page
     , deepseq
     , directory
     , filepath

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -19,6 +19,7 @@ import           System.Environment (getEnvironment)
 import           System.Exit (exitFailure, exitSuccess)
 import           System.FilePath ((</>), takeExtension)
 import           System.IO
+import           System.IO.CodePage (withCP65001)
 
 import qualified Control.Exception as E
 import           Panic
@@ -144,5 +145,5 @@ doctest_ args = do
   -- get examples from Haddock comments
   modules <- getDocTests args
 
-  Interpreter.withInterpreter args $ \repl -> do
+  Interpreter.withInterpreter args $ \repl -> withCP65001 $ do
     runModules repl modules


### PR DESCRIPTION
Fixes #148.

Some notes about `code-page`: it's a small little library that I whipped up to solve a similar Unicode-printing issue in `criterion` (see https://github.com/bos/criterion/issues/100 / https://github.com/bos/criterion/pull/125). It depends on solely `base` (and `Win32`, on Windows). On Windows, it uses `bracket` to temporarily change the codepage to CP65001 (which supports UTF-8) and the encoding to `utf8`. On other OSes, it does nothing.

I don't know if you can really test for this, since the bug is an issue with the way Windows consoles display certain characters. But I verified that the example in #148 does print out properly on PowerShell and MSYS2 now.