### PR TITLE
Add support to regex lines starting with ~~~

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -212,6 +212,16 @@ anything *within that line*:
 -- foo ... baz
 ```
 
+The lines starting with three tildes (`~~~`) will be matched using
+[`regex-tdfa`](https://hackage.haskell.org/package/regex-tdfa)
+regular expressions
+
+```haskell
+-- |
+-- >>> putStrLn "foo bar baz"
+-- ~~~o{2}
+```
+
 ### QuickCheck properties
 
 Haddock (since version 2.13.0) has markup support for properties.  Doctest can

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -50,7 +50,7 @@ library
     , Language.Haskell.GhciWrapper
   build-depends:
       base          == 4.*
-    , base-compat   >= 0.7.0
+    , base-compat   >= 0.8.0
     , ghc           >= 7.0 && < 8.4
     , syb           >= 0.3
     , code-page     >= 0.1
@@ -59,6 +59,7 @@ library
     , filepath
     , process
     , ghc-paths     >= 0.1.0.9
+    , regex-tdfa    >= 1.1.8
     , transformers
 
 executable doctest
@@ -96,6 +97,7 @@ test-suite spec
     , process
     , ghc-paths
     , transformers
+    , regex-tdfa
 
     , base-compat
     , HUnit

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 module Parse (
   Module (..)
 , DocTest (..)
@@ -17,13 +16,12 @@ module Parse (
 , mkLineChunks
 ) where
 
+import           Prelude ()
+import           Prelude.Compat
 import           Data.Char (isSpace)
-import           Data.List
+import           Data.List.Compat
 import           Data.Maybe
 import           Data.String
-#if __GLASGOW_HASKELL__ < 710
-import           Control.Applicative
-#endif
 import           Extract
 import           Location
 
@@ -37,7 +35,7 @@ data LineChunk = LineChunk String | WildCardChunk
 instance IsString LineChunk where
     fromString = LineChunk
 
-data ExpectedLine = ExpectedLine [LineChunk] | WildCardLine
+data ExpectedLine = ExpectedLine [LineChunk] | RegexLine String | WildCardLine
   deriving (Show, Eq)
 
 instance IsString ExpectedLine where
@@ -154,6 +152,7 @@ mkExpectedLine :: String -> ExpectedLine
 mkExpectedLine x = case x of
     "<BLANKLINE>" -> ""
     "..." -> WildCardLine
+    _ | "~~~" `isPrefixOf` x -> RegexLine (drop 3 x)
     _ -> ExpectedLine $ mkLineChunks x
 
 mkLineChunks :: String -> [LineChunk]

--- a/test/ParseSpec.hs
+++ b/test/ParseSpec.hs
@@ -171,6 +171,14 @@ spec = do
         " bar"
       `shouldBe` [("action", ["foo", WildCardLine, "bar"])]
 
+    it "parses regex lines" $ do
+      parse_ $ do
+        " >>> action"
+        " foo"
+        " ~~~o{2}"
+        " bar"
+      `shouldBe` [("action", ["foo", RegexLine "o{2}", "bar"])]
+
     it "parses wild card chunks" $ do
       parse_ $ do
         " >>> action"

--- a/test/Runner/ExampleSpec.hs
+++ b/test/Runner/ExampleSpec.hs
@@ -55,6 +55,14 @@ spec = do
         property $ \xs -> mkResult (lineToExpected xs) (lineToActual xs)
             `shouldBe` Equal
 
+    context "with RegexLine" $ do
+      it "matches line against the regexp" $ do
+        mkResult ["foo", RegexLine "x{2}", "bar"] ["foo", "..xx..x.xx..", "bar"]
+            `shouldBe` Equal
+
+        mkResult ["foo", RegexLine "^x{2}", "bar"] ["foo", "..xx..x.xx..", "bar"]
+            `shouldNotBe` Equal
+
     context "with WildCardChunk" $ do
       it "matches an arbitrary line chunk" $ do
         mkResult [ExpectedLine ["foo", WildCardChunk, "bar"]] ["foo baz bar"]


### PR DESCRIPTION
There are cases where ... is just not enough, e.g. when matching against
possible error messages of GHC

Motivated by https://github.com/haskell-servant/servant/issues/698 and
https://github.com/haskell-servant/servant/pull/699
Making a doctests for "should not type check", working across
GHC 7.8.4 - GHC 8.0.2 is practically impossible without regular
expression.

*EDIT* compiles also with GHC-7.0.4.