### PR TITLE
Adds --no-magic flag

### DIFF
--- a/src/Help.hs
+++ b/src/Help.hs
@@ -11,13 +11,14 @@ import           Interpreter (ghc)
 usage :: String
 usage = unlines [
           "Usage:"
-        , "  doctest [ GHC OPTION | MODULE ]..."
+        , "  doctest [ --no-magic | GHC OPTION | MODULE ]..."
         , "  doctest --help"
         , "  doctest --version"
         , ""
         , "Options:"
         , "  --help     display this help and exit"
         , "  --version  output version information and exit"
+        , "  --no-magic no directory expansion, and no argument discovery."
         ]
 
 printVersion :: IO ()


### PR DESCRIPTION
Under certain conditions you might want to sidestep the directory
expansion and auto argument discovery.  `--no-magic` provides this.
External tools invoking doctest, and wishing full control over the
passed argument, might want to use `--no-magic`.

This should fix the first part of #155.