### PR TITLE
Adds --numeric-version and --ghc-numeric-version

### DIFF
--- a/src/Help.hs
+++ b/src/Help.hs
@@ -1,7 +1,8 @@
 module Help (
   usage
 , printVersion
-, printGhcVersion
+, printNumericVersion
+, printGhcNumericVersion
 ) where
 
 import           Paths_doctest (version)
@@ -19,8 +20,10 @@ usage = unlines [
         , "Options:"
         , "  --help     display this help and exit"
         , "  --version  output version information and exit"
-        , "  --ghc-version"
-        , "             output the ghc version identical to ghc --version"
+        , "  --numeric-version"
+        , "             output just the version"
+        , "  --ghc-numeric-version"
+        , "             output the ghc version identical to ghc --numeric-version"
         ]
 
 printVersion :: IO ()
@@ -29,6 +32,8 @@ printVersion = do
   putStrLn ("using version " ++ GHC.cProjectVersion ++ " of the GHC API")
   putStrLn ("using " ++ ghc)
 
-printGhcVersion :: IO ()
-printGhcVersion =
-  putStrLn (GHC.cProjectName ++ ", version " ++ GHC.cProjectVersion)
+printNumericVersion :: IO ()
+printNumericVersion = putStrLn (showVersion version)
+
+printGhcNumericVersion :: IO ()
+printGhcNumericVersion = putStrLn GHC.cProjectVersion

--- a/src/Help.hs
+++ b/src/Help.hs
@@ -1,6 +1,7 @@
 module Help (
   usage
 , printVersion
+, printGhcVersion
 ) where
 
 import           Paths_doctest (version)
@@ -18,6 +19,8 @@ usage = unlines [
         , "Options:"
         , "  --help     display this help and exit"
         , "  --version  output version information and exit"
+        , "  --ghc-version"
+        , "             output the ghc version identical to ghc --version"
         ]
 
 printVersion :: IO ()
@@ -25,3 +28,7 @@ printVersion = do
   putStrLn ("doctest version " ++ showVersion version)
   putStrLn ("using version " ++ GHC.cProjectVersion ++ " of the GHC API")
   putStrLn ("using " ++ ghc)
+
+printGhcVersion :: IO ()
+printGhcVersion =
+  putStrLn (GHC.cProjectName ++ ", version " ++ GHC.cProjectVersion)

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -44,9 +44,10 @@ import qualified Interpreter
 -- inside of it, ignoring hidden entries.
 doctest :: [String] -> IO ()
 doctest args0
-  | "--help"        `elem` args0 = putStr usage
-  | "--version"     `elem` args0 = printVersion
-  | "--ghc-version" `elem` args0 = printGhcVersion
+  | "--help"                `elem` args0 = putStr usage
+  | "--version"             `elem` args0 = printVersion
+  | "--numeric-version"     `elem` args0 = printNumericVersion
+  | "--ghc-numeric-version" `elem` args0 = printGhcNumericVersion
   | otherwise = do
       args <- concat <$> mapM expandDirs args0
       i <- Interpreter.interpreterSupported

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -44,8 +44,9 @@ import qualified Interpreter
 -- inside of it, ignoring hidden entries.
 doctest :: [String] -> IO ()
 doctest args0
-  | "--help"    `elem` args0 = putStr usage
-  | "--version" `elem` args0 = printVersion
+  | "--help"        `elem` args0 = putStr usage
+  | "--version"     `elem` args0 = printVersion
+  | "--ghc-version" `elem` args0 = printGhcVersion
   | otherwise = do
       args <- concat <$> mapM expandDirs args0
       i <- Interpreter.interpreterSupported


### PR DESCRIPTION
This allows to parse the ghc version from doctest with any parser
that can parse `ghc --version` already.

Fixes #157 