### PR TITLE
Guard unperformant compatibility hack behind CPP

### DIFF
--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -123,7 +123,13 @@ runModule repl (Module module_ setup examples) = do
       runTestGroup repl setup_
   where
     reload :: IO ()
-    reload = void $ Interpreter.safeEval repl $ ":m *" ++ module_
+    reload = do
+#if __GLASGOW_HASKELL__ < 707
+      -- NOTE: It is important to do the :reload first!  There was some odd bug
+      -- with a previous versions of GHC (7.6.3 and older).
+      void $ Interpreter.safeEval repl   ":reload"
+#endif
+      void $ Interpreter.safeEval repl $ ":m *" ++ module_
 
     setup_ :: IO ()
     setup_ = do

--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -123,11 +123,7 @@ runModule repl (Module module_ setup examples) = do
       runTestGroup repl setup_
   where
     reload :: IO ()
-    reload = do
-      -- NOTE: It is important to do the :reload first!  There was some odd bug
-      -- with a previous version of GHC (7.4.1?).
-      void $ Interpreter.safeEval repl   ":reload"
-      void $ Interpreter.safeEval repl $ ":m *" ++ module_
+    reload = void $ Interpreter.safeEval repl $ ":m *" ++ module_
 
     setup_ :: IO ()
     setup_ = do


### PR DESCRIPTION
This compatibility hack ~~doesn't seem to be necessary for the final patch releases of all the GHC releases from 7.0.4 up to 8.2.1~~ (EDIT: It's needed for GHC 7.6.3 and older, sadly). Moreover, it causes severe performance issues, so there's good cause to ~~remove it~~ (guard it behind CPP).

Fixes #164.