### PR TITLE
Add --fast flag

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+Changes in next
+  - Add `--fast`, which disables running `:reload` between example groups
+
 Changes in 0.11.3
   - Add `--info`
   - Add `--no-magic`

--- a/README.markdown
+++ b/README.markdown
@@ -88,6 +88,16 @@ for
 
 `print n` is not tried, because `let n = x + y` fails (`y` is not in scope!).
 
+#### A note on performance
+
+By default, `doctest` calls `:reload` between each group to clear GHCi's scope
+of any local definitions. This ensures that previous examples cannot influence
+later ones. However, it can lead to performance penalties if you are using
+`doctest` in a project with many modules. One possible remedy is to pass the
+`--fast` flag to `doctest`, which disables calling `:reload` between groups.
+If `doctest`s are running too slowly, you might consider using `--fast`.
+(With the caveat that the order in which groups appear now matters!)
+
 ### Setup code
 
 You can put setup code in a [named chunk][named-chunks] with the name `$setup`.

--- a/test/OptionsSpec.hs
+++ b/test/OptionsSpec.hs
@@ -11,15 +11,19 @@ spec = do
     let warning = ["WARNING: --optghc is deprecated, doctest now accepts arbitrary GHC options\ndirectly."]
     it "strips --optghc" $
       property $ \xs ys ->
-        parseOptions (xs ++ ["--optghc", "foobar"] ++ ys) `shouldBe` Result (Run warning (xs ++ ["foobar"] ++ ys) True)
+        parseOptions (xs ++ ["--optghc", "foobar"] ++ ys) `shouldBe` Result (Run warning (xs ++ ["foobar"] ++ ys) True False)
 
     it "strips --optghc=" $
       property $ \xs ys ->
-        parseOptions (xs ++ ["--optghc=foobar"] ++ ys) `shouldBe` Result (Run warning (xs ++ ["foobar"] ++ ys) True)
+        parseOptions (xs ++ ["--optghc=foobar"] ++ ys) `shouldBe` Result (Run warning (xs ++ ["foobar"] ++ ys) True False)
 
     context "with --no-magic" $ do
       it "disables magic mode" $ do
-        parseOptions ["--no-magic"] `shouldBe` Result (Run [] [] False)
+        parseOptions ["--no-magic"] `shouldBe` Result (Run [] [] False False)
+
+    context "with --fast" $ do
+      it "enabled fast mode" $ do
+        parseOptions ["--fast"] `shouldBe` Result (Run [] [] True True)
 
     context "with --help" $ do
       it "outputs usage information" $ do


### PR DESCRIPTION
Add an optional `--fast` flag, which disables `:reload`s between example groups.

Follow-up to #165. Fixes #164.