### PR TITLE
Turn Travis green (hopefully)

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -102,7 +102,7 @@ test-suite spec
     , base-compat
     , HUnit
     , hspec         >= 1.5.1
-    , QuickCheck    >= 2.8.2
+    , QuickCheck    >= 2.11.3
     , stringbuilder >= 0.4
     , silently      >= 1.2.4
     , setenv

--- a/test/PropertySpec.hs
+++ b/test/PropertySpec.hs
@@ -49,7 +49,7 @@ spec = do
       runProperty repl "\\x -> x + y == y + x" `shouldReturn` Success
 
     it "reports the value for which a property fails" $ withInterpreter [] $ \repl -> do
-      runProperty repl "x == 23" `shouldReturn` Failure "*** Failed! Falsifiable (after 1 test): \n0"
+      runProperty repl "x == 23" `shouldReturn` Failure "*** Failed! Falsifiable (after 1 test):\n0"
 
     it "reports the values for which a property that takes multiple arguments fails" $ withInterpreter [] $ \repl -> do
       let vals x = case x of (Failure r) -> tail (lines r); _ -> error "Property did not fail!"


### PR DESCRIPTION
QuickCheck changed its output slightly at some point between 2.10 and
2.11.3, and this was breaking one of the tests. It's easier to just
update to the newer output and bump the lower bound.