### PR TITLE
Reduce Travis build time by only downloading specific GHCs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,48 @@ sudo: false
 
 language: c
 
-env:
-  - GHCVER=7.6.3
-  - GHCVER=7.8.4
-  - GHCVER=7.10.3
-  - GHCVER=8.0.2
-  - GHCVER=8.2.1
-
-addons:
-  apt:
-    sources:
-      - hvr-ghc
-    packages:
-      - ghc-7.6.3
-      - ghc-7.8.4
-      - ghc-7.10.3
-      - ghc-8.0.2
-      - ghc-8.2.1
-      - cabal-install-1.24
+matrix:
+  include:
+    - env: GHCVER=7.6.3
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-7.6.3
+            - cabal-install-1.24
+    - env: GHCVER=7.8.4
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-7.8.4
+            - cabal-install-1.24
+    - env: GHCVER=7.10.3
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-7.10.3
+            - cabal-install-1.24
+    - env: GHCVER=8.0.2
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-8.0.2
+            - cabal-install-1.24
+    - env: GHCVER=8.2.1
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-8.2.1
+            - cabal-install-1.24
 
 before_install:
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/1.24/bin:$PATH


### PR DESCRIPTION
Previously, we were downloading all GHC versions every build! This
should speed things up.

[Before:  56 min 24 sec total, longest build is 12 min 29 sec.](https://travis-ci.org/sol/doctest/builds/338855738)

[After: 34 min 36 sec total, longest build is 9 min 56 sec.](https://travis-ci.org/quasicomputational/doctest/builds/339109352)