### PR TITLE
Fix the build with GHC 7.0 and 7.2

### DIFF
--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -14,7 +14,7 @@ module Runner (
 import           Prelude hiding (putStr, putStrLn, error)
 
 #if __GLASGOW_HASKELL__ < 710
-import           Data.Monoid hiding ((<>))
+import           Data.Monoid (Monoid(..))
 import           Control.Applicative
 #endif
 


### PR DESCRIPTION
`doctest-0.14.1` [no longer builds](https://travis-ci.org/ekmett/comonad/jobs/346296665#L638) with GHC 7.0 or 7.2:

```
[14 of 16] Compiling Runner           ( src/Runner.hs, dist/build/Runner.o )

src/Runner.hs:17:38: Module `Data.Monoid' does not export `(<>)'
```

This is easily fixed by changing the imports from `Data.Monoid` to be explicit.