### PR TITLE
Require base-4.5 or later

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -1,8 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.26.0.
+-- This file has been generated from package.yaml by hpack version 0.27.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0a29aaff0365fc3bd51a91801874db9f7286c473371a385a2d6ec0c8dfb48e6e
+-- hash: 3c0e7fcde23be36c2db1a7350efe4ee58a6c4ca032fe19cb8d7f1cbbc7853a85
 
 name:           doctest
 version:        0.14.1
@@ -130,7 +130,7 @@ library
       Language.Haskell.GhciWrapper
       Paths_doctest
   build-depends:
-      base ==4.*
+      base >=4.5
     , base-compat >=0.7.0
     , code-page >=0.1
     , deepseq
@@ -151,7 +151,7 @@ executable doctest
   hs-source-dirs:
       driver
   build-depends:
-      base ==4.*
+      base >=4.5
     , base-compat >=0.7.0
     , code-page >=0.1
     , deepseq
@@ -172,7 +172,7 @@ test-suite doctests
   hs-source-dirs:
       test
   build-depends:
-      base ==4.*
+      base >=4.5
     , base-compat >=0.7.0
     , code-page >=0.1
     , deepseq
@@ -231,7 +231,7 @@ test-suite spec
   build-depends:
       HUnit
     , QuickCheck >=2.11.3
-    , base ==4.*
+    , base >=4.5
     , base-compat >=0.7.0
     , code-page >=0.1
     , deepseq

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3c0e7fcde23be36c2db1a7350efe4ee58a6c4ca032fe19cb8d7f1cbbc7853a85
+-- hash: 054c306e552f0abe320fe8ddf4b247a8d2cf1ab185edc53fb27e7444f3f47007
 
 name:           doctest
 version:        0.14.1
@@ -130,7 +130,7 @@ library
       Language.Haskell.GhciWrapper
       Paths_doctest
   build-depends:
-      base >=4.5
+      base >=4.5 && <5
     , base-compat >=0.7.0
     , code-page >=0.1
     , deepseq
@@ -151,7 +151,7 @@ executable doctest
   hs-source-dirs:
       driver
   build-depends:
-      base >=4.5
+      base >=4.5 && <5
     , base-compat >=0.7.0
     , code-page >=0.1
     , deepseq
@@ -172,7 +172,7 @@ test-suite doctests
   hs-source-dirs:
       test
   build-depends:
-      base >=4.5
+      base >=4.5 && <5
     , base-compat >=0.7.0
     , code-page >=0.1
     , deepseq
@@ -231,7 +231,7 @@ test-suite spec
   build-depends:
       HUnit
     , QuickCheck >=2.11.3
-    , base >=4.5
+    , base >=4.5 && <5
     , base-compat >=0.7.0
     , code-page >=0.1
     , deepseq

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ extra-source-files:
 ghc-options: -Wall
 
 dependencies:
-- base >= 4.5
+- base >= 4.5 && < 5
 - base-compat >= 0.7.0
 - ghc >= 7.0 && < 8.6
 - syb >= 0.3

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ synopsis:         Test interactive Haskell examples
 description: |
   The doctest program checks examples in source code comments.  It is modeled
   after doctest for Python (<http://docs.python.org/library/doctest.html>).
-  
+
   Documentation is at <https://github.com/sol/doctest#readme>.
 category:         Testing
 license:          MIT
@@ -27,7 +27,7 @@ extra-source-files:
 ghc-options: -Wall
 
 dependencies:
-- base == 4.*
+- base >= 4.5
 - base-compat >= 0.7.0
 - ghc >= 7.0 && < 8.6
 - syb >= 0.3


### PR DESCRIPTION
Per https://github.com/sol/doctest/pull/194#issuecomment-369461104, @sol no longer wishes to support GHC 7.0 and 7.2. Indicate this explicitly by bumping up the lower version bounds on `base`.