### PR TITLE
Make output more standard

### DIFF
--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -158,14 +158,14 @@ reportStart loc expression testType = do
 
 reportFailure :: Location -> Expression -> [String] -> Report ()
 reportFailure loc expression err = do
-  report (printf "### Failure in %s: expression `%s'" (show loc) expression)
+  report (printf "%s: failure: expression `%s'" (show loc) expression)
   mapM_ report err
   report ""
   updateSummary (Summary 0 1 0 1)
 
 reportError :: Location -> Expression -> String -> Report ()
 reportError loc expression err = do
-  report (printf "### Error in %s: expression `%s'" (show loc) expression)
+  report (printf "%s: error: expression `%s'" (show loc) expression)
   report err
   report ""
   updateSummary (Summary 0 1 1 0)

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -128,7 +128,7 @@ spec = do
               "### Started execution at test/integration/failing/Foo.hs:5."
             , "### example:"
             , "23"
-            , "### Failure in test/integration/failing/Foo.hs:5: expression `23'"
+            , "test/integration/failing/Foo.hs:5: failure: expression `23'"
             , "expected: 42"
             , " but got: 23"
             , ""


### PR DESCRIPTION
This PR makes `doctest` use the same output format for errors as GHC and `hspec`. One benefit of it is that we get jump-to-error-location out of the box (at least in Emacs), while with the previous format we don't.