### PR TITLE
Add --no-interpret flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,22 +44,22 @@ matrix:
           packages:
             - ghc-8.2.1
             - cabal-install-1.24
-    - env: GHCVER=8.4.1 CABALVER=head
+    - env: GHCVER=8.4.4 CABALVER=2.4
       addons:
         apt:
           sources:
             - hvr-ghc
           packages:
-            - ghc-8.4.1
-            - cabal-install-head
-    - env: GHCVER=8.6.1 CABALVER=head
+            - ghc-8.4.4
+            - cabal-install-2.4
+    - env: GHCVER=8.6.3 CABALVER=2.4
       addons:
         apt:
           sources:
             - hvr-ghc
           packages:
-            - ghc-8.6.1
-            - cabal-install-head
+            - ghc-8.6.3
+            - cabal-install-2.4
     - env: GHCVER=head CABALVER=head
       addons:
         apt:

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -26,7 +26,7 @@ doctest = doctestWithPreserveIt defaultPreserveIt
 
 doctestWithPreserveIt :: WithLocation (Bool -> FilePath -> [String] -> Summary -> Assertion)
 doctestWithPreserveIt preserveIt workingDir args expected = do
-  actual <- withCurrentDirectory ("test/integration" </> workingDir) (hSilence [stderr] $ doctestWithOptions defaultFastMode preserveIt defaultVerbose args)
+  actual <- withCurrentDirectory ("test/integration" </> workingDir) (hSilence [stderr] $ doctestWithOptions defaultFastMode preserveIt defaultInterpret defaultVerbose args)
   assertEqual label expected actual
   where
     label = workingDir ++ " " ++ show args

--- a/test/OptionsSpec.hs
+++ b/test/OptionsSpec.hs
@@ -14,11 +14,11 @@ spec = do
     let warning = ["WARNING: --optghc is deprecated, doctest now accepts arbitrary GHC options\ndirectly."]
     it "strips --optghc" $
       property $ \xs ys ->
-        parseOptions (xs ++ ["--optghc", "foobar"] ++ ys) `shouldBe` Result (Run warning (xs ++ ["foobar"] ++ ys) defaultMagic defaultFastMode defaultPreserveIt defaultVerbose)
+        parseOptions (xs ++ ["--optghc", "foobar"] ++ ys) `shouldBe` Result (Run warning (xs ++ ["foobar"] ++ ys) defaultMagic defaultFastMode defaultPreserveIt defaultInterpret defaultVerbose)
 
     it "strips --optghc=" $
       property $ \xs ys ->
-        parseOptions (xs ++ ["--optghc=foobar"] ++ ys) `shouldBe` Result (Run warning (xs ++ ["foobar"] ++ ys) defaultMagic defaultFastMode defaultPreserveIt defaultVerbose)
+        parseOptions (xs ++ ["--optghc=foobar"] ++ ys) `shouldBe` Result (Run warning (xs ++ ["foobar"] ++ ys) defaultMagic defaultFastMode defaultPreserveIt defaultInterpret defaultVerbose)
 
     describe "--no-magic" $ do
       context "without --no-magic" $ do
@@ -46,6 +46,18 @@ spec = do
       context "with --preserve-it" $ do
         it "preserves the `it` variable" $ do
           runPreserveIt <$> parseOptions ["--preserve-it"] `shouldBe` Result True
+
+    describe "--no-interpret" $ do
+      context "without --no-interpret" $ do
+        it "interprets modules" $ do
+          runInterpret <$> parseOptions [] `shouldBe` Result True
+
+      context "with --no-interpret" $ do
+        it "loads modules" $ do
+          runInterpret <$> parseOptions ["--no-interpret"] `shouldBe` Result False
+
+        it "disables magic mode" $ do
+          runMagicMode <$> parseOptions ["--no-interpret"] `shouldBe` Result False
 
     context "with --help" $ do
       it "outputs usage information" $ do

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -25,7 +25,7 @@ import qualified Options
 import           Run
 
 doctestWithDefaultOptions :: [String] -> IO Summary
-doctestWithDefaultOptions = doctestWithOptions Options.defaultFastMode Options.defaultPreserveIt Options.defaultVerbose
+doctestWithDefaultOptions = doctestWithOptions Options.defaultFastMode Options.defaultPreserveIt Options.defaultInterpret Options.defaultVerbose
 
 withCurrentDirectory :: FilePath -> IO a -> IO a
 withCurrentDirectory workingDir action = do


### PR DESCRIPTION
If the flag is passed
- it implies --no-magic
- it makes doctest load modules with :m +Module.Name, (not star!)
  i.e. no interpret, just load
- and also filters all arguments which don't start with a dash
  to the GHCi invocation

This feature is useful in a case, where you want to test
a package inside bigger package-set. As current "package"
is only used to extract doctest strings, you essentially
can use whatever modules you want; as long as GHCi can load them.

Without `--no-interpret`, it is easy to run into a situation
where you have conflicting definitions: one loaded and one interpretted.

The cons of --no-interpet is that you need to explicitly
import everything you need, i.e. imports aren't inherited.
Also you cannot use -D__DOCTEST__ trick to provide auxiliary
definitions.