### PR TITLE
Add support for explicit package ids with HASKELL_PACKAGE_IDS var

### DIFF
--- a/src/PackageDBs.hs
+++ b/src/PackageDBs.hs
@@ -69,7 +69,7 @@ buildArgStyle = Pre76
 getPackageDBsFromEnv :: IO PackageDBs
 getPackageDBsFromEnv = do
     env <- getEnvironment
-    let packageIds = words <$> lookup "HASKELL_PACKAGE_IDS" env
+    let packageIds = fmap words $ lookup "HASKELL_PACKAGE_IDS" env
         fromEnvMulti s = PackageDBs
             { includeUser = False
             , includeGlobal = global


### PR DESCRIPTION
This should fix #119 when using Stack after https://github.com/commercialhaskell/stack/pull/4533 gets merged. I suppose it shouldn't be hard to add similar support to Cabal.