### PR TITLE
Fix expected QuickCheck output for failures.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 NEXT
   - Fix loading plugins in doctests. (#224)
+  - Require QuickCheck 2.13.1 or newer.
 
 Changes in 0.16.1
   - Remove dependency on `with-location`

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -230,7 +230,7 @@ test-suite spec
       test/integration/with-cbits/foo.c
   build-depends:
       HUnit
-    , QuickCheck >=2.11.3
+    , QuickCheck >=2.13.1
     , base >=4.5 && <5
     , base-compat >=0.7.0
     , code-page >=0.1

--- a/test/PropertySpec.hs
+++ b/test/PropertySpec.hs
@@ -18,7 +18,7 @@ spec :: Spec
 spec = do
   describe "runProperty" $ do
     it "reports a failing property" $ withInterpreter [] $ \repl -> do
-      runProperty repl "False" `shouldReturn` Failure "*** Failed! Falsifiable (after 1 test):"
+      runProperty repl "False" `shouldReturn` Failure "*** Failed! Falsified (after 1 test):"
 
     it "runs a Bool property" $ withInterpreter [] $ \repl -> do
       runProperty repl "True" `shouldReturn` Success
@@ -49,7 +49,7 @@ spec = do
       runProperty repl "\\x -> x + y == y + x" `shouldReturn` Success
 
     it "reports the value for which a property fails" $ withInterpreter [] $ \repl -> do
-      runProperty repl "x == 23" `shouldReturn` Failure "*** Failed! Falsifiable (after 1 test):\n0"
+      runProperty repl "x == 23" `shouldReturn` Failure "*** Failed! Falsified (after 1 test):\n0"
 
     it "reports the values for which a property that takes multiple arguments fails" $ withInterpreter [] $ \repl -> do
       let vals x = case x of (Failure r) -> tail (lines r); _ -> error "Property did not fail!"


### PR DESCRIPTION
This changed at some point lately and it's causing our tests to fail.