### PR TITLE
Let internal GHC options override user-supplied ones

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 Changes in HEAD (unreleased)
+  - Add doctest's necessary-for-operation options to GHC's command
+    line at the end, so that they over-ride anything provided by the
+    user. (#233)
 
 Changes in 0.16.1
   - Fix loading plugins in doctests. (#224)

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -53,13 +53,13 @@ withInterpreter
   -> IO a                   -- ^ Result of action
 withInterpreter flags action = do
   let
-    args = [
+    args = flags ++ [
         "--interactive"
 #if __GLASGOW_HASKELL__ >= 802
       , "-fdiagnostics-color=never"
       , "-fno-diagnostics-show-caret"
 #endif
-      ] ++ flags
+      ]
   bracket (new defaultConfig{configGhci = ghc} args) close action
 
 -- | Evaluate an expression; return a Left value on exceptions.

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -136,6 +136,9 @@ spec = do
             , "Examples: 1  Tried: 1  Errors: 0  Failures: 1"
         ]
 
+    it "can deal with potentially problematic GHC options" $ do
+      hSilence [stderr] $ doctest ["-fdiagnostics-color=always", "test/integration/color/Foo.hs"]
+
   describe "doctestWithOptions" $ do
     context "on parse error" $ do
       let action = withCurrentDirectory "test/integration/parse-error" (doctestWithDefaultOptions ["Foo.hs"])

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -136,8 +136,10 @@ spec = do
             , "Examples: 1  Tried: 1  Errors: 0  Failures: 1"
         ]
 
+#if __GLASGOW_HASKELL__ >= 802
     it "can deal with potentially problematic GHC options" $ do
       hSilence [stderr] $ doctest ["-fdiagnostics-color=always", "test/integration/color/Foo.hs"]
+#endif
 
   describe "doctestWithOptions" $ do
     context "on parse error" $ do

--- a/test/integration/color/Foo.hs
+++ b/test/integration/color/Foo.hs
@@ -1,0 +1,8 @@
+module Foo where
+
+import Data.Maybe
+
+-- | Convert a map into list array.
+-- prop> tabulate m !! fromEnum d == fromMaybe 0 (lookup d m)
+tabulate :: [(Bool, Double)] -> [Double]
+tabulate m = [fromMaybe 0 $ lookup False m, fromMaybe 0 $ lookup True m]


### PR DESCRIPTION
This is necessary for doctest to operate correctly when the user passes GHC flags like `-fdiagnostics-color=always` to it.

Here is an example module `doctest` fails to process when given with `-fdiagnostics-color=always`.

```haskell
module Foo where

import Data.Maybe

-- | Convert a map into a 2D array.
-- prop> tabulate m !! fromEnum d !! fromEnum p == fromMaybe 0 (lookup (d, p) m)
tabulate :: [((Bool, Bool), Double)] -> [[Double]]
tabulate = undefined
```