### PR TITLE
Negative tests

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d5abcdee934975b9568a6a1bc0ee5c43fe8a4ef688cb3c0797de506fe2df0005
+-- hash: fa92185bfdd4cfc520c50219ff6acaa72d01c9718ce06bec9019a7ad2e04fe49
 
 name:           doctest
 version:        0.16.1.1
@@ -62,6 +62,7 @@ extra-source-files:
     test/integration/bugfixWorkingDirectory/description
     test/integration/bugfixWorkingDirectory/examples/Fib.hs
     test/integration/bugfixWorkingDirectory/Fib.hs
+    test/integration/color/Foo.hs
     test/integration/custom-package-conf/Bar.hs
     test/integration/custom-package-conf/foo/doctest-foo.cabal
     test/integration/custom-package-conf/foo/Foo.hs

--- a/src/Runner/Example.hs
+++ b/src/Runner/Example.hs
@@ -16,10 +16,9 @@ data Result = Equal | NotEqual [String]
 mkResult :: ExpectedResult -> [String] -> Result
 mkResult (ExpectedResult expected) actual
   | expected `matches` actual = Equal
-  | otherwise = NotEqual (formatNotEqual expected actual)
+  | otherwise = NotEqual (formatNotEqual "expected" expected actual)
 mkResult (UnexpectedResult expected) actual
-  -- TODO(sandy): make a formatequal
-  | expected `matches` actual = NotEqual (formatNotEqual expected actual)
+  | expected `matches` actual = NotEqual (formatNotEqual "didn't expect" expected actual)
   | otherwise = Equal
 
 chunksMatch :: [LineChunk] -> String -> Bool
@@ -40,8 +39,8 @@ matches [] _  = False
 matches _  [] = False
 
 
-formatNotEqual :: [ExpectedLine] -> [String] -> [String]
-formatNotEqual expected_ actual = formatLines "expected: " expected ++ formatLines " but got: " actual
+formatNotEqual :: String -> [ExpectedLine] -> [String] -> [String]
+formatNotEqual expected_message expected_ actual = formatLines (expected_message ++ ": ") expected ++ formatLines " but got: " actual
   where
     expected :: [String]
     expected = map (\x -> case x of
@@ -63,6 +62,7 @@ formatNotEqual expected_ actual = formatLines "expected: " expected ++ formatLin
       []   -> [message]
       where
         padding = replicate (length message) ' '
+
 
 lineChunkToString :: LineChunk -> String
 lineChunkToString WildCardChunk = "..."

--- a/test/ParseSpec.hs
+++ b/test/ParseSpec.hs
@@ -177,7 +177,7 @@ spec = do
         " foo ... bar"
       `shouldBe` [("action", ExpectedResult [ExpectedLine ["foo ", WildCardChunk, " bar"]])]
 
-  describe "jank" $ do
+  describe "parse unexpected" $ do
     let parse_ = map unLoc . parseInteractions . noLocation . build
 
     it "parses wild cards lines" $ do

--- a/test/Runner/ExampleSpec.hs
+++ b/test/Runner/ExampleSpec.hs
@@ -97,16 +97,32 @@ spec = do
         mkRes UnexpectedResult (map fromString xs) xs `shouldSatisfy` isNotEqual
 
     it "ignores trailing whitespace" $ do
-      mkRes UnexpectedResult ["foo\t"] ["foo  "] `shouldBe` NotEqual [""]
+      mkRes UnexpectedResult ["foo\t"] ["foo  "]
+          `shouldBe` NotEqual ["didn't expect: \"foo\\t\""
+                              ," but got: \"foo  \""
+                              ]
 
     context "with WildCardLine" $ do
       it "matches zero lines" $ do
         mkRes UnexpectedResult ["foo", WildCardLine, "bar"] ["foo", "bar"]
-            `shouldBe` NotEqual [""]
+            `shouldBe` NotEqual ["didn't expect: foo"
+                                ,"               ..."
+                                ,"               bar"
+                                ," but got: foo"
+                                ,"          bar"
+                                ]
 
       it "matches an arbitrary number of lines" $ do
         mkRes UnexpectedResult ["foo", WildCardLine, "bar"] ["foo", "baz", "bazoom", "bar"]
-            `shouldBe` NotEqual [""]
+            `shouldBe` NotEqual ["didn't expect: foo"
+                                ,"               ..."
+                                ,"               bar"
+                                ," but got: foo"
+                                ,"          baz"
+                                ,"          bazoom"
+                                ,"          bar"
+                                ]
+
 
       it "matches an arbitrary number of lines (quickcheck)" $ do
         property $ \xs -> mkResult (lineToExpected UnexpectedResult xs) (lineToActual xs)

--- a/test/Runner/ExampleSpec.hs
+++ b/test/Runner/ExampleSpec.hs
@@ -92,7 +92,7 @@ spec = do
             ]
 
   describe "mkRes UnexpectedResult" $ do
-    it "returns Equal when output matches" $ do
+    it "returns NotEqual when output matches" $ do
       property $ \xs -> do
         mkRes UnexpectedResult (map fromString xs) xs `shouldSatisfy` isNotEqual
 
@@ -136,12 +136,12 @@ spec = do
                                 ]
 
     context "when output does not match" $ do
-      it "constructs failure message" $ do
+      it "returns Equal" $ do
         mkRes UnexpectedResult ["foo"] ["bar"] `shouldBe` Equal
 
-      it "constructs failure message for multi-line output" $ do
+      it "returns equal for multi-line output" $ do
         mkRes UnexpectedResult ["foo", "bar"] ["foo", "baz"] `shouldBe` Equal
 
       context "when any output line contains \"unsafe\" characters" $ do
-        it "uses show to format output lines" $ do
+        it "returns equal" $ do
           mkRes UnexpectedResult ["foo\160bar"] ["foo bar"] `shouldBe` Equal


### PR DESCRIPTION
This PR adds support for expected failures-to-match. The primary use case is for ensuring custom type errors don't leak underlying implementation details.

For example, the doctest:

```haskell
-- >>> :{
-- foo :: TypeError (Text "Don't define foo" ) => ()
-- foo = 5
-- :}
-- !!!...
-- ... No instance for (Num ()) ...
-- ...
```

will _succeed_, because the custom type error overrides the usual `No instance for (Num ()) arising from the literal ‘5’` error.

The semantics are that an expected output that begins with `!!!` will match the output as usual, but negate whether or not that should fail.

This PR is just a proof of concept. I'm not very happy with the `!!!` syntax or my janky parsing logic. Any suggestions here would be appreciated.

Fixes #234