### PR TITLE
Mark position of difference.

### DIFF
--- a/src/Runner/Example.hs
+++ b/src/Runner/Example.hs
@@ -13,52 +13,141 @@ data Result = Equal | NotEqual [String]
   deriving (Eq, Show)
 
 mkResult :: ExpectedResult -> [String] -> Result
-mkResult expected actual
-  | expected `matches` actual = Equal
-  | otherwise = NotEqual (formatNotEqual expected actual)
+mkResult expected_ actual_ =
+  case expected `matches` actual of
+  FullMatch                 -> Equal
+  PartialMatch row expanded -> NotEqual (formatNotEqual expected actual expanded row)
   where
-    chunksMatch :: [LineChunk] -> String -> Bool
-    chunksMatch [] "" = True
-    chunksMatch [LineChunk xs] ys = stripEnd xs == stripEnd ys
+    -- use show to escape special characters in output lines if any output line
+    -- contains any unsafe character
+    escapeOutput
+      | any (not . isSafe) $ concat (expectedAsString ++ actual_) = init . tail . show . stripEnd
+      | otherwise = id
+
+    actual :: [String]
+    actual = fmap escapeOutput actual_
+
+    expected :: ExpectedResult
+    expected = fmap (transformExcpectedLine escapeOutput) expected_
+
+    expectedAsString :: [String]
+    expectedAsString = map (\x -> case x of
+        ExpectedLine str -> concatMap lineChunkToString str
+        WildCardLine -> "..." ) expected_
+
+    isSafe :: Char -> Bool
+    isSafe c = c == ' ' || (isPrint c && (not . isSpace) c)
+
+    chunksMatch :: [LineChunk] -> String -> LineMatch
+    chunksMatch [] "" = FullLineMatch
+    chunksMatch [LineChunk xs] ys =
+      if stripEnd xs == stripEnd ys
+      then FullLineMatch
+      else matchingPrefix xs ys
     chunksMatch (LineChunk x : xs) ys =
-        x `isPrefixOf` ys && xs `chunksMatch` drop (length x) ys
+      if x `isPrefixOf` ys
+      then (xs `chunksMatch` drop (length x) ys) `prependText` x
+      else matchingPrefix x ys
     chunksMatch zs@(WildCardChunk : xs) (_:ys) =
-        xs `chunksMatch` ys || zs `chunksMatch` ys
-    chunksMatch _ _ = False
+      let resWithoutWC = xs `chunksMatch` ys in
+      let resWithWC = zs `chunksMatch` ys in
+      let res = longerMatch resWithoutWC resWithWC in
+      prependWildcard res
+    chunksMatch [WildCardChunk] [] = FullLineMatch
+    chunksMatch (WildCardChunk:_) [] = PartialLineMatch "" ""
+    chunksMatch [] (_:_) = PartialLineMatch "" ""
 
-    matches :: ExpectedResult -> [String] -> Bool
-    matches (ExpectedLine x : xs) (y : ys) = x `chunksMatch` y && xs `matches` ys
-    matches (WildCardLine : xs) ys | xs `matches` ys = True
-    matches zs@(WildCardLine : _) (_ : ys) = zs `matches` ys
-    matches [] [] = True
-    matches [] _  = False
-    matches _  [] = False
+    matchingPrefix xs ys =
+      let common = fmap fst (takeWhile (\(x, y) -> x == y) (xs `zip` ys)) in
+      PartialLineMatch common common
 
+    matches :: ExpectedResult -> [String] -> Match
+    matches (ExpectedLine x : xs) (y : ys) =
+      case x `chunksMatch` y of
+      FullLineMatch -> incLineNo $ xs `matches` ys
+      PartialLineMatch _ expanded -> PartialMatch 1 expanded
+    matches zs@(WildCardLine : xs) us@(_ : ys) =
+      let matchWithoutWC = xs `matches` us in
+      let matchWithWC    = zs `matches` ys in
+      matchWithoutWC `matchMax` (incLineNo matchWithWC)
+      where
+        matchMax FullMatch _ = FullMatch
+        matchMax _ FullMatch = FullMatch
+        matchMax m1 m2 =
+          if length (partialLine m1) > length (partialLine m2)
+          then m1
+          else if length (partialLine m2) > length (partialLine m2)
+          then m2
+          else if mismatchLineNo m1 > mismatchLineNo m2
+          then m1
+          else m2
+    matches [WildCardLine] [] = FullMatch
+    matches [] [] = FullMatch
+    matches [] _  = PartialMatch 1 ""
+    matches _  [] = PartialMatch 1 ""
 
-formatNotEqual :: ExpectedResult -> [String] -> [String]
-formatNotEqual expected_ actual = formatLines "expected: " expected ++ formatLines " but got: " actual
+data LineMatch = FullLineMatch | PartialLineMatch { matchingText :: String, _expandedWildcards :: String }
+  deriving (Show)
+
+prependText :: LineMatch -> String -> LineMatch
+prependText FullLineMatch _ = FullLineMatch
+prependText (PartialLineMatch mt wct) s = PartialLineMatch (s++mt) (s++wct)
+
+prependWildcard :: LineMatch -> LineMatch
+prependWildcard FullLineMatch = FullLineMatch
+prependWildcard (PartialLineMatch mt wct) = PartialLineMatch mt ('.':wct)
+
+longerMatch :: LineMatch -> LineMatch -> LineMatch
+longerMatch FullLineMatch _ = FullLineMatch
+longerMatch _ FullLineMatch = FullLineMatch
+longerMatch m1 m2 =
+  if length (matchingText m1) > length (matchingText m2) then m1 else m2
+
+data Match = FullMatch | PartialMatch { mismatchLineNo :: Int, partialLine :: String }
+  deriving (Show)
+
+incLineNo :: Match -> Match
+incLineNo FullMatch = FullMatch
+incLineNo (PartialMatch lineNo partialLineMatch) = PartialMatch (lineNo + 1) partialLineMatch
+
+formatNotEqual :: ExpectedResult -> [String] -> String -> Int -> [String]
+formatNotEqual expected_ actual expanded row = formatLines "expected: " expected ++ formatLines " but got: " (lineMarker wildcard expanded row actual)
   where
     expected :: [String]
     expected = map (\x -> case x of
         ExpectedLine str -> concatMap lineChunkToString str
         WildCardLine -> "..." ) expected_
 
-    -- use show to escape special characters in output lines if any output line
-    -- contains any unsafe character
-    escapeOutput
-      | any (not . isSafe) (concat $ expected ++ actual) = map show
-      | otherwise = id
-
-    isSafe :: Char -> Bool
-    isSafe c = c == ' ' || (isPrint c && (not . isSpace) c)
-
     formatLines :: String -> [String] -> [String]
-    formatLines message xs = case escapeOutput xs of
+    formatLines message xs = case xs of
       y:ys -> (message ++ y) : map (padding ++) ys
       []   -> [message]
       where
         padding = replicate (length message) ' '
 
+    wildcard :: Bool
+    wildcard = any (\x -> case x of
+        ExpectedLine xs -> any (\y -> case y of { WildCardChunk -> True; _ -> False }) xs
+        WildCardLine -> True ) expected_
+
 lineChunkToString :: LineChunk -> String
 lineChunkToString WildCardChunk = "..."
 lineChunkToString (LineChunk str) = str
+
+transformExcpectedLine :: (String -> String) -> ExpectedLine -> ExpectedLine
+transformExcpectedLine f (ExpectedLine xs) =
+  ExpectedLine $ fmap (\el -> case el of
+    LineChunk s -> LineChunk $ f s
+    WildCardChunk -> WildCardChunk
+  ) xs
+transformExcpectedLine _ WildCardLine = WildCardLine
+
+lineMarker :: Bool -> String -> Int -> [String] -> [String]
+lineMarker wildcard expanded row actual =
+  let (pre, post) = splitAt row actual in
+  pre ++
+  [(if wildcard && length expanded > 30
+    -- show expanded pattern if match is long, to help understanding what matched what
+    then expanded
+    else replicate (length expanded) ' ') ++ "^"] ++
+  post

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -131,6 +131,7 @@ spec = do
             , "test/integration/failing/Foo.hs:5: failure in expression `23'"
             , "expected: 42"
             , " but got: 23"
+            , "          ^"
             , ""
             , "# Final summary:"
             , "Examples: 1  Tried: 1  Errors: 0  Failures: 1"

--- a/test/Runner/ExampleSpec.hs
+++ b/test/Runner/ExampleSpec.hs
@@ -47,6 +47,14 @@ spec = do
         mkResult ["foo", WildCardLine, "bar"] ["foo", "bar"]
             `shouldBe` Equal
 
+      it "matches first zero line" $ do
+        mkResult [WildCardLine, "foo", "bar"] ["foo", "bar"]
+            `shouldBe` Equal
+
+      it "matches final zero line" $ do
+        mkResult ["foo", "bar", WildCardLine] ["foo", "bar"]
+            `shouldBe` Equal
+
       it "matches an arbitrary number of lines" $ do
         mkResult ["foo", WildCardLine, "bar"] ["foo", "baz", "bazoom", "bar"]
             `shouldBe` Equal
@@ -60,11 +68,32 @@ spec = do
         mkResult [ExpectedLine ["foo", WildCardChunk, "bar"]] ["foo baz bar"]
             `shouldBe` Equal
 
+      it "matches an arbitrary line chunk at end" $ do
+        mkResult [ExpectedLine ["foo", WildCardChunk]] ["foo baz bar"]
+            `shouldBe` Equal
+
+      it "does not match at end" $ do
+        mkResult [ExpectedLine [WildCardChunk, "baz"]] ["foo baz bar"]
+            `shouldBe` NotEqual [
+                 "expected: ...baz"
+               , " but got: foo baz bar"
+               , "                 ^"
+               ]
+
+      it "does not match at start" $ do
+        mkResult [ExpectedLine ["fuu", WildCardChunk]] ["foo baz bar"]
+            `shouldBe` NotEqual [
+                 "expected: fuu..."
+               , " but got: foo baz bar"
+               , "           ^"
+               ]
+
     context "when output does not match" $ do
       it "constructs failure message" $ do
         mkResult ["foo"] ["bar"] `shouldBe` NotEqual [
             "expected: foo"
           , " but got: bar"
+          , "          ^"
           ]
 
       it "constructs failure message for multi-line output" $ do
@@ -73,11 +102,59 @@ spec = do
           , "          bar"
           , " but got: foo"
           , "          baz"
+          , "            ^"
           ]
 
       context "when any output line contains \"unsafe\" characters" $ do
         it "uses show to format output lines" $ do
           mkResult ["foo\160bar"] ["foo bar"] `shouldBe` NotEqual [
-              "expected: \"foo\\160bar\""
-            , " but got: \"foo bar\""
+              "expected: foo\\160bar"
+            , " but got: foo bar"
+            , "             ^"
             ]
+
+      it "insert caret after last matching character on different lengths" $ do
+        mkResult ["foo"] ["fo"] `shouldBe` NotEqual [
+            "expected: foo"
+          , " but got: fo"
+          , "            ^"
+          ]
+
+      it "insert caret after mismatching line for multi-line output" $ do
+        mkResult ["foo", "bar", "bat"] ["foo", "baz", "bax"] `shouldBe` NotEqual [
+            "expected: foo"
+          , "          bar"
+          , "          bat"
+          , " but got: foo"
+          , "          baz"
+          , "            ^"
+          , "          bax"
+          ]
+
+      it "insert caret after mismatching line with the longest match for multi-line wildcard pattern" $ do
+        mkResult ["foo", WildCardLine, "bar", "bat"] ["foo", "xxx", "yyy", "baz", "bxx"] `shouldBe` NotEqual [
+            "expected: foo"
+          , "          ..."
+          , "          bar"
+          , "          bat"
+          , " but got: foo"
+          , "          xxx"
+          , "          yyy"
+          , "          baz"
+          , "            ^"
+          , "          bxx"
+          ]
+
+      it "insert caret after longest match for wildcard" $ do
+        mkResult [ExpectedLine ["foo ", WildCardChunk, " bar bat"]] ["foo xxx yyy baz bxx"] `shouldBe` NotEqual [
+            "expected: foo ... bar bat"
+          , " but got: foo xxx yyy baz bxx"
+          , "                        ^"
+          ]
+
+      it "show expanded pattern for long matches" $ do
+        mkResult [ExpectedLine ["foo ", WildCardChunk, " bar bat"]] ["foo 123456789 123456789 xxx yyy baz bxx"] `shouldBe` NotEqual [
+            "expected: foo ... bar bat"
+          , " but got: foo 123456789 123456789 xxx yyy baz bxx"
+          , "          foo ........................... ba^"
+          ]


### PR DESCRIPTION
Fixes #206 by placing a caret (^) pointing at the character that is different in the result.