### PR TITLE
.cabal description: update docs.python.org url

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -10,7 +10,7 @@ name:           doctest
 version:        0.17
 synopsis:       Test interactive Haskell examples
 description:    The doctest program checks examples in source code comments.  It is modeled
-                after doctest for Python (<http://docs.python.org/library/doctest.html>).
+                after doctest for Python (<https://docs.python.org/3/library/doctest.html>).
                 .
                 Documentation is at <https://github.com/sol/doctest#readme>.
 category:       Testing


### PR DESCRIPTION
http://docs.python.org/ redirects to https://docs.python.org/3/

[skip ci]