### PR TITLE
GHC 9 compatibility fixes

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -1,16 +1,16 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6671c3bec33afff6873246f7b4a0f0b525135af9e29d05ba1a45d528979511ac
+-- hash: bc5b28df6d1ba7069d1dacee1914ab861df5a61ab4b4b5865db813b198e6bbb0
 
 name:           doctest
 version:        0.17
 synopsis:       Test interactive Haskell examples
 description:    The doctest program checks examples in source code comments.  It is modeled
-                after doctest for Python (<https://docs.python.org/3/library/doctest.html>).
+                after doctest for Python (<http://docs.python.org/library/doctest.html>).
                 .
                 Documentation is at <https://github.com/sol/doctest#readme>.
 category:       Testing
@@ -137,11 +137,14 @@ library
     , deepseq
     , directory
     , filepath
-    , ghc >=7.0 && <8.11
+    , ghc >=7.0 && <9.1
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
     , transformers
+  if impl(ghc>=8.11)
+    build-depends:
+        exceptions
   default-language: Haskell2010
 
 executable doctest
@@ -159,11 +162,14 @@ executable doctest
     , directory
     , doctest
     , filepath
-    , ghc >=7.0 && <8.11
+    , ghc >=7.0 && <9.1
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
     , transformers
+  if impl(ghc>=8.11)
+    build-depends:
+        exceptions
   default-language: Haskell2010
 
 test-suite doctests
@@ -180,11 +186,14 @@ test-suite doctests
     , directory
     , doctest
     , filepath
-    , ghc >=7.0 && <8.11
+    , ghc >=7.0 && <9.1
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
     , transformers
+  if impl(ghc>=8.11)
+    build-depends:
+        exceptions
   default-language: Haskell2010
 
 test-suite spec
@@ -238,7 +247,7 @@ test-suite spec
     , deepseq
     , directory
     , filepath
-    , ghc >=7.0 && <8.11
+    , ghc >=7.0 && <9.1
     , ghc-paths >=0.1.0.9
     , hspec >=2.3.0
     , hspec-core >=2.3.0
@@ -249,4 +258,7 @@ test-suite spec
     , stringbuilder >=0.4
     , syb >=0.3
     , transformers
+  if impl(ghc>=8.11)
+    build-depends:
+        exceptions
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,7 @@ ghc-options: -Wall
 dependencies:
 - base >= 4.5 && < 5
 - base-compat >= 0.7.0
-- ghc >= 7.0 && < 8.11
+- ghc >= 7.0 && < 9.1
 - syb >= 0.3
 - code-page >= 0.1
 - deepseq
@@ -38,6 +38,11 @@ dependencies:
 - process
 - ghc-paths >= 0.1.0.9
 - transformers
+
+when:
+  - condition: impl(ghc>=8.11)
+    dependencies:
+    - exceptions
 
 library:
   source-dirs:

--- a/src/GhcUtil.hs
+++ b/src/GhcUtil.hs
@@ -6,13 +6,20 @@ import           GHC.Paths (libdir)
 import           Control.Exception
 import           GHC hiding (flags)
 import           DynFlags (dopt_set)
-#else
+import           Panic (throwGhcException)
+import           MonadUtils (liftIO)
+#elif __GLASGOW_HASKELL__ < 811
 import           GHC
 import           DynFlags (gopt_set)
-#endif
 import           Panic (throwGhcException)
-
 import           MonadUtils (liftIO)
+#else
+import           GHC
+import           GHC.Driver.Session (gopt_set)
+import           GHC.Utils.Panic (throwGhcException)
+import           Control.Monad.IO.Class (liftIO)
+#endif
+
 import           System.Exit (exitFailure)
 
 #if __GLASGOW_HASKELL__ < 702
@@ -83,7 +90,11 @@ setHaddockMode dynflags = (dopt_set dynflags Opt_Haddock) {
 #else
 setHaddockMode dynflags = (gopt_set dynflags Opt_Haddock) {
 #endif
-      hscTarget = HscNothing
-    , ghcMode   = CompManager
-    , ghcLink   = NoLink
+#if __GLASGOW_HASKELL__ < 811
+    hscTarget = HscNothing,
+#else
+    backend   = NoBackend,
+#endif
+    ghcMode   = CompManager,
+    ghcLink   = NoLink
     }

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -23,7 +23,11 @@ import           Data.Maybe
 
 import qualified Paths_doctest
 import           Data.Version (showVersion)
+#if __GLASGOW_HASKELL__ < 811
 import           Config as GHC
+#else
+import           GHC.Settings.Config as GHC
+#endif
 import           Interpreter (ghc)
 
 usage :: String
@@ -47,7 +51,7 @@ version :: String
 version = showVersion Paths_doctest.version
 
 ghcVersion :: String
-ghcVersion = GHC.cProjectVersion
+ghcVersion = cProjectVersion
 
 versionInfo :: String
 versionInfo = unlines [

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -20,7 +20,11 @@ import           System.IO
 import           System.IO.CodePage (withCP65001)
 
 import qualified Control.Exception as E
+#if __GLASGOW_HASKELL__ < 811
 import           Panic
+#else
+import           GHC.Utils.Panic
+#endif
 
 import           PackageDBs
 import           Parse

--- a/test/ExtractSpec.hs
+++ b/test/ExtractSpec.hs
@@ -1,11 +1,16 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 module ExtractSpec (main, spec) where
 
 import           Test.Hspec
 import           Test.HUnit
 
+#if __GLASGOW_HASKELL__ < 811
 import           Panic (GhcException (..))
+#else
+import           GHC.Utils.Panic (GhcException (..))
+#endif
 
 import           Extract
 import           Location

--- a/test/LocationSpec.hs
+++ b/test/LocationSpec.hs
@@ -1,10 +1,16 @@
+{-# LANGUAGE CPP #-}
 module LocationSpec (main, spec) where
 
 import           Test.Hspec
 
 import           Location
+#if __GLASGOW_HASKELL__ < 811
 import           SrcLoc
 import           FastString (fsLit)
+#else
+import           GHC.Types.SrcLoc
+import           GHC.Data.FastString (fsLit)
+#endif
 
 main :: IO ()
 main = hspec spec


### PR DESCRIPTION
The main change is the module reorganisation, and there are a few minor changes:

* Now GHC uses hierarchical modules, so I had to add a bunch of conditionals to import the newer modules. This is the bulk of changes.
* GHC removed its exception utilities with `exceptions` package, so we now conditionally depend on it. (GHC rev: `30272412fa437ab8e7a8035db94a278e10513413`)
* `HscTarget` is replaced by `Backend` (GHC rev: `f7cc431341e5b5b31758eecc8504cae8b2390c10`)
* `RealSrcSpan`'s have one more field (GHC rev: `327b29e1a05d9f1ea04465c9b23aed92473dd453`)

I only tested this with GHC 9, so I am relying on CI tests to fail for older releases.