### PR TITLE
Sync package.yaml with doctest.cabal

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6671c3bec33afff6873246f7b4a0f0b525135af9e29d05ba1a45d528979511ac
+-- hash: 91bcc4835263e32dea79bfc514fa9b67ff53c7b1c43a1e39dbc63a1f6e4ee773
 
 name:           doctest
 version:        0.17

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@ version:          0.17
 synopsis:         Test interactive Haskell examples
 description: |
   The doctest program checks examples in source code comments.  It is modeled
-  after doctest for Python (<http://docs.python.org/library/doctest.html>).
+  after doctest for Python (<https://docs.python.org/3/library/doctest.html>).
 
   Documentation is at <https://github.com/sol/doctest#readme>.
 category:         Testing


### PR DESCRIPTION
The latter was hand-modified; this is just propagating the change to
the canonical source.