### PR TITLE
Support GHC-9.2 (fix #305) (pr #306)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,48 +12,73 @@ jobs:
     strategy:
       matrix:
         include:
+          - ghc: "9.2.1"
+            cabal: "3.6"
+            setup-method: ghcup
+            allow-failure: false
           - ghc: "9.0.1"
             cabal: "3.4"
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: "8.10.4"
+          - ghc: "8.10.7"
             cabal: "3.2"
+            setup-method: ghcup
             allow-failure: false
           - ghc: "8.8.4"
             cabal: "3.0"
+            setup-method: hvr-ppa
             allow-failure: false
           - ghc: "8.6.5"
             cabal: "2.4"
+            setup-method: hvr-ppa
             allow-failure: false
           - ghc: "8.4.4"
             cabal: "2.4"
+            setup-method: hvr-ppa
             allow-failure: false
           - ghc: "8.2.2"
             cabal: "2.4"
+            setup-method: hvr-ppa
             allow-failure: false
           - ghc: "8.0.2"
             cabal: "2.4"
+            setup-method: hvr-ppa
             allow-failure: false
           - ghc: "7.10.3"
             cabal: "2.4"
+            setup-method: hvr-ppa
             allow-failure: false
           - ghc: "7.8.4"
             cabal: "2.4"
+            setup-method: hvr-ppa
             allow-failure: false
           - ghc: "7.6.3"
             cabal: "2.4"
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: apt
+      - name: apt and ghcup
         run: |
           apt-get update
-          apt-get install -y software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y "ghc-$GHC_VERSION" "cabal-install-$CABAL_VERSION"
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          mkdir -p "$HOME/.ghcup/bin"
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc --set "$GHC_VERSION"
+            "$HOME/.ghcup/bin/ghcup" install cabal "$CABAL_VERSION"
+            ls -al "$HOME/.ghcup/bin/"
+          elif [ "${{ matrix.setup-method }}" = hvr-ppa ]; then
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "ghc-$GHC_VERSION" "cabal-install-$CABAL_VERSION"
+          else
+            echo "Invalid setup method: ${{ matrix.setup }}" && false
+          fi
         env:
           GHC_VERSION: ${{ matrix.ghc }}
           CABAL_VERSION: ${{ matrix.cabal }}
@@ -61,7 +86,7 @@ jobs:
       - name: env vars
         run: |
           echo "LC_ALL=C.UTF-8" >> $GITHUB_ENV
-          echo "/opt/ghc/$GHC_VERSION/bin:/opt/cabal/$CABAL_VERSION/bin:$PATH" >> $GITHUB_PATH
+          echo "$HOME/.ghcup/bin:/opt/ghc/$GHC_VERSION/bin:/opt/cabal/$CABAL_VERSION/bin:$PATH" >> $GITHUB_PATH
           CABAL_OPTS=""
           case "$GHC_VERSION" in
           head )
@@ -75,9 +100,10 @@ jobs:
 
       - name: haskell deps
         run: |
+          echo "$PATH"
           ghc --version
           cabal --version
-          cabal v1-update
+          cabal update
           sed -i 's/^jobs:/-- jobs:/' "${HOME}/.cabal/config"
           cd "$GITHUB_WORKSPACE"
           cabal v1-install --enable-tests --only-dep $CABAL_OPTS

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+Changes in 0.18.2
+  - GHC 9.2 compatibility. (#305, thanks to Ryan Scott and Matthew Pickering)
+
 Changes in 0.18.1
   - GHC 9.0 compatibility. (#275)
 

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.3.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a7c307d4c3548326994e6fb1f8f2e96fd825cb9ba3cf2ed3cc6ea352a2554436
+-- hash: b9de129664477df8d95442dafaf0d5443d65b63949e3a96307ba0169e2d83936
 
 name:           doctest
-version:        0.18.1
+version:        0.18.2
 synopsis:       Test interactive Haskell examples
 description:    The doctest program checks examples in source code comments.  It is modeled
                 after doctest for Python (<https://docs.python.org/3/library/doctest.html>).
@@ -31,8 +31,9 @@ tested-with:
   , GHC == 8.4.4
   , GHC == 8.6.5
   , GHC == 8.8.4
-  , GHC == 8.10.4
+  , GHC == 8.10.7
   , GHC == 9.0.1
+  , GHC == 9.2.1
 extra-source-files:
     example/example.cabal
     example/src/Example.hs
@@ -148,7 +149,7 @@ library
     , directory
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.1
+    , ghc >=7.0 && <9.3
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
@@ -171,7 +172,7 @@ executable doctest
     , doctest
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.1
+    , ghc >=7.0 && <9.3
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
@@ -193,7 +194,7 @@ test-suite doctests
     , doctest
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.1
+    , ghc >=7.0 && <9.3
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
@@ -250,7 +251,7 @@ test-suite spec
     , directory
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.1
+    , ghc >=7.0 && <9.3
     , ghc-paths >=0.1.0.9
     , hspec >=2.3.0
     , hspec-core >=2.3.0

--- a/ghci-wrapper/src/Language/Haskell/GhciWrapper.hs
+++ b/ghci-wrapper/src/Language/Haskell/GhciWrapper.hs
@@ -15,7 +15,7 @@ import           System.Process
 import           System.Exit
 import           Control.Monad
 import           Control.Exception
-import           Data.List
+import           Data.List (isSuffixOf)
 import           Data.Maybe
 
 data Config = Config {

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:             doctest
-version:          0.18.1
+version:          0.18.2
 synopsis:         Test interactive Haskell examples
 description: |
   The doctest program checks examples in source code comments.  It is modeled
@@ -24,8 +24,9 @@ tested-with:
 - GHC == 8.4.4
 - GHC == 8.6.5
 - GHC == 8.8.4
-- GHC == 8.10.4
+- GHC == 8.10.7
 - GHC == 9.0.1
+- GHC == 9.2.1
 
 extra-source-files:
 - example/**/*
@@ -40,7 +41,7 @@ ghc-options: -Wall
 dependencies:
 - base >= 4.5 && < 5
 - base-compat >= 0.7.0
-- ghc >= 7.0 && < 9.1
+- ghc >= 7.0 && < 9.3
 - syb >= 0.3
 - code-page >= 0.1
 - deepseq

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -104,12 +104,6 @@ instance NFData a => NFData (Module a) where
 
 #if __GLASGOW_HASKELL__ < 803
 type GhcPs = RdrName
-
--- needsTemplateHaskellOrQQ :: ModuleGraph -> Bool
--- needsTemplateHaskellOrQQ = needsTemplateHaskell
-
--- mapMG :: (ModSummary -> ModSummary) -> ModuleGraph -> ModuleGraph
--- mapMG = map
 #endif
 
 #if __GLASGOW_HASKELL__ < 805
@@ -131,8 +125,6 @@ parse args = withGhc args $ \modules_ -> withTempOutputDir $ do
                 Nothing)
   mods <- depanal [] False
 
-  --mods' <- if needsTemplateHaskellOrQQ mods then enableCompilation mods else return mods
-
   let sortedMods = flattenSCCs
 #if __GLASGOW_HASKELL__ >= 901
                      $ filterToposortToModules
@@ -140,26 +132,6 @@ parse args = withGhc args $ \modules_ -> withTempOutputDir $ do
                      $ topSortModuleGraph False mods Nothing
   reverse <$> mapM (loadModPlugins >=> parseModule) sortedMods
   where
-{-
-    -- copied from Haddock/Interface.hs
-    enableCompilation :: ModuleGraph -> Ghc ModuleGraph
-    enableCompilation modGraph = do
-#if __GLASGOW_HASKELL__ < 707
-      let enableComp d = d { hscTarget = defaultObjectTarget }
-#elif __GLASGOW_HASKELL__ < 809
-      let enableComp d = let platform = targetPlatform d
-                         in d { hscTarget = defaultObjectTarget platform }
-#elif __GLASGOW_HASKELL__ < 901
-      let enableComp d = d { hscTarget = defaultObjectTarget d }
-#else
-      let enableComp d = d { backend = platformDefaultBackend (targetPlatform d) }
-#endif
-      modifySessionDynFlags enableComp
-      -- We need to update the DynFlags of the ModSummaries as well.
-      let upd m = m { ms_hspp_opts = enableComp (ms_hspp_opts m) }
-      let modGraph' = mapMG upd modGraph
-      return modGraph'
--}
 
     -- copied from Haddock/GhcUtils.hs
     modifySessionDynFlags :: (DynFlags -> DynFlags) -> Ghc ()

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -66,6 +66,11 @@ import           GHC.Runtime.Loader (initializePlugins)
 #endif
 #endif
 
+#if __GLASGOW_HASKELL__ >= 901
+import           GHC.Driver.Env
+import           GHC.Unit.Module.Graph
+#endif
+
 -- | A wrapper around `SomeException`, to allow for a custom `Show` instance.
 newtype ExtractError = ExtractError SomeException
   deriving Typeable
@@ -114,20 +119,29 @@ addQuoteInclude includes new = new ++ includes
 #endif
 
 -- | Parse a list of modules.
-parse :: [String] -> IO [TypecheckedModule]
+parse :: [String] -> IO [ParsedModule]
 parse args = withGhc args $ \modules_ -> withTempOutputDir $ do
 
   -- ignore additional object files
   let modules = filter (not . isSuffixOf ".o") modules_
 
-  mapM (`guessTarget` Nothing) modules >>= setTargets
+  setTargets =<< forM modules (\ m -> guessTarget m
+#if __GLASGOW_HASKELL__ >= 903
+                Nothing
+#endif
+                Nothing)
   mods <- depanal [] False
 
-  mods' <- if needsTemplateHaskellOrQQ mods then enableCompilation mods else return mods
+  --mods' <- if needsTemplateHaskellOrQQ mods then enableCompilation mods else return mods
 
-  let sortedMods = flattenSCCs (topSortModuleGraph False mods' Nothing)
-  reverse <$> mapM (loadModPlugins >=> parseModule >=> typecheckModule >=> loadModule) sortedMods
+  let sortedMods = flattenSCCs
+#if __GLASGOW_HASKELL__ >= 901
+                     $ filterToposortToModules
+#endif
+                     $ topSortModuleGraph False mods Nothing
+  reverse <$> mapM (loadModPlugins >=> parseModule) sortedMods
   where
+{-
     -- copied from Haddock/Interface.hs
     enableCompilation :: ModuleGraph -> Ghc ModuleGraph
     enableCompilation modGraph = do
@@ -136,14 +150,17 @@ parse args = withGhc args $ \modules_ -> withTempOutputDir $ do
 #elif __GLASGOW_HASKELL__ < 809
       let enableComp d = let platform = targetPlatform d
                          in d { hscTarget = defaultObjectTarget platform }
-#else
+#elif __GLASGOW_HASKELL__ < 901
       let enableComp d = d { hscTarget = defaultObjectTarget d }
+#else
+      let enableComp d = d { backend = platformDefaultBackend (targetPlatform d) }
 #endif
       modifySessionDynFlags enableComp
       -- We need to update the DynFlags of the ModSummaries as well.
       let upd m = m { ms_hspp_opts = enableComp (ms_hspp_opts m) }
       let modGraph' = mapMG upd modGraph
       return modGraph'
+-}
 
     -- copied from Haddock/GhcUtils.hs
     modifySessionDynFlags :: (DynFlags -> DynFlags) -> Ghc ()
@@ -191,8 +208,16 @@ parse args = withGhc args $ \modules_ -> withTempOutputDir $ do
     -- Since GHC 8.6, plugins are initialized on a per module basis
     loadModPlugins modsum = do
       hsc_env <- getSession
+# if __GLASGOW_HASKELL__ >= 903
+      hsc_env' <- liftIO (initializePlugins hsc_env Nothing)
+      return $ modsum { ms_hspp_opts = hsc_dflags hsc_env' }
+# elif __GLASGOW_HASKELL__ >= 901
+      hsc_env' <- liftIO (initializePlugins hsc_env)
+      return $ modsum { ms_hspp_opts = hsc_dflags hsc_env' }
+# else
       dynflags' <- liftIO (initializePlugins hsc_env (GHC.ms_hspp_opts modsum))
       return $ modsum { ms_hspp_opts = dynflags' }
+# endif
 #else
     loadModPlugins = return
 #endif
@@ -206,7 +231,7 @@ extract args = do
   packageDBArgs <- getPackageDBArgs
   let args'  = args ++ packageDBArgs
   mods <- parse args'
-  let docs = map (fmap (fmap convertDosLineEndings) . extractFromModule . tm_parsed_module) mods
+  let docs = map (fmap (fmap convertDosLineEndings) . extractFromModule) mods
 
   (docs `deepseq` return docs) `catches` [
       -- Re-throw AsyncException, otherwise execution will not terminate on
@@ -238,13 +263,15 @@ docStringsFromModule mod = map (fmap (toLocated . fmap unpackHDS)) docs
     -- traversing the whole source in a generic way, to ensure that we get
     -- everything in source order.
     header  = [(Nothing, x) | Just x <- [hsmodHaddockModHeader source]]
+    exports = [ (Nothing, L (locA loc) doc)
 #if __GLASGOW_HASKELL__ < 710
-    exports = [(Nothing, L loc doc) | L loc (IEDoc doc) <- concat (hsmodExports source)]
+              | L loc (IEDoc doc) <- concat (hsmodExports source)
 #elif __GLASGOW_HASKELL__ < 805
-    exports = [(Nothing, L loc doc) | L loc (IEDoc doc) <- maybe [] unLoc (hsmodExports source)]
+              | L loc (IEDoc doc) <- maybe [] unLoc (hsmodExports source)
 #else
-    exports = [(Nothing, L loc doc) | L loc (IEDoc _ doc) <- maybe [] unLoc (hsmodExports source)]
+              | L loc (IEDoc _ doc) <- maybe [] unLoc (hsmodExports source)
 #endif
+              ]
     decls   = extractDocStrings (hsmodDecls source)
 
 type Selector a = a -> ([(Maybe String, LHsDocString)], Bool)
@@ -298,15 +325,21 @@ extractDocStrings = everythingBut (++) (([], False) `mkQ` fromLHsDecl
       -- no location information attached.  The location information is
       -- attached to HsDecl instead.
 #if __GLASGOW_HASKELL__ < 805
-      DocD x -> select (fromDocDecl loc x)
+      DocD x
 #else
-      DocD _ x -> select (fromDocDecl loc x)
+      DocD _ x
 #endif
+               -> select (fromDocDecl (locA loc) x)
 
       _ -> (extractDocStrings decl, True)
 
-    fromLDocDecl :: Selector LDocDecl
-    fromLDocDecl (L loc x) = select (fromDocDecl loc x)
+    fromLDocDecl :: Selector
+#if __GLASGOW_HASKELL__ >= 901
+                             (LDocDecl GhcPs)
+#else
+                             LDocDecl
+#endif
+    fromLDocDecl (L loc x) = select (fromDocDecl (locA loc) x)
 
     fromLHsDocString :: Selector LHsDocString
     fromLHsDocString x = select (Nothing, x)
@@ -320,4 +353,9 @@ extractDocStrings = everythingBut (++) (([], False) `mkQ` fromLHsDecl
 -- | Convert a docstring to a plain string.
 unpackHDS :: HsDocString -> String
 unpackHDS (HsDocString s) = unpackFS s
+#endif
+
+#if __GLASGOW_HASKELL__ < 901
+locA :: SrcSpan -> SrcSpan
+locA = id
 #endif

--- a/src/GhcUtil.hs
+++ b/src/GhcUtil.hs
@@ -81,7 +81,8 @@ handleStaticFlags flags = return $ map noLoc $ flags
 handleDynamicFlags :: GhcMonad m => [Located String] -> m [String]
 handleDynamicFlags flags = do
 #if __GLASGOW_HASKELL__ >= 901
-  parseDynamicFlags' <- parseDynamicFlags =<< getLogger
+  logger <- getLogger
+  let parseDynamicFlags' = parseDynamicFlags logger
 #else
   let parseDynamicFlags' = parseDynamicFlags
 #endif

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -22,7 +22,7 @@ import           Control.Monad.Trans.RWS (RWS, execRWS)
 import qualified Control.Monad.Trans.RWS as RWS
 
 import           Control.Monad (when)
-import           Data.List.Compat
+import           Data.List.Compat (intercalate, stripPrefix)
 import           Data.Monoid (Endo (Endo))
 
 import qualified Paths_doctest

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -18,7 +18,7 @@ module Parse (
 ) where
 
 import           Data.Char (isSpace)
-import           Data.List
+import           Data.List (isPrefixOf, stripPrefix)
 import           Data.Maybe
 import           Data.String
 #if __GLASGOW_HASKELL__ < 710

--- a/src/Runner/Example.hs
+++ b/src/Runner/Example.hs
@@ -4,7 +4,7 @@ module Runner.Example (
 ) where
 
 import           Data.Char
-import           Data.List
+import           Data.List (isPrefixOf)
 import           Util
 
 import           Parse

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -9,7 +9,7 @@ import           System.Exit
 
 import qualified Control.Exception as E
 import           System.Directory (getCurrentDirectory, setCurrentDirectory)
-import           Data.List.Compat
+import           Data.List.Compat (isPrefixOf, sort)
 
 import           System.IO.Silently
 import           System.IO (stderr)


### PR DESCRIPTION
GHC-9.2 compatibility (fix #305)

With this commit, based on @RyanGlScott's patch, building with
```
cabal v1-install --enable-tests --allow-newer=hsc2hs:base --allow-newer=ghc-paths:Cabal
cabal v1-test
```
the tests pass except for the `TemplateHaskell` ones (see below).
This could be due to some commented out code in `src/Extract.hs`,
cutting out the type-checking phase:
```diff
-  mods' <- if needsTemplateHaskellOrQQ mods then enableCompilation mods else return mods
+  --mods' <- if needsTemplateHaskellOrQQ mods then enableCompilation mods else return mods

-  let sortedMods = flattenSCCs (topSortModuleGraph False mods' Nothing)
-  reverse <$> mapM (loadModPlugins >=> parseModule >=> typecheckModule >=> loadModule) sortedMods
+  let sortedMods = flattenSCCs
+#if __GLASGOW_HASKELL__ >= 901
+                     $ filterToposortToModules
+#endif
+                     $ topSortModuleGraph False mods Nothing
+  reverse <$> mapM (loadModPlugins >=> parseModule) sortedMods
```
@RyanGlScott, do you remember why you did this change?

Test failure:
```
test/extract/th/Foo.hs:8:7: warning: [-Woperator-whitespace-ext-conflict]
    The prefix use of a ‘$’ would denote an untyped splice
      were the TemplateHaskell extension enabled.
    Suggested fix: add whitespace after the ‘$’.
  |
8 | foo = $(bar)
  |       ^

test/extract/th/Foo.hs:8:7: error:
    parse error on input ‘$’
    Perhaps you intended to use TemplateHaskell
  |
8 | foo = $(bar)
  |       ^

Failures:

  test/ExtractSpec.hs:91:5:
  1) Extract, extract (regression tests), works with a module that splices in an expression from an other module
       uncaught exception: ExitCode
       ExitFailure 1

  To rerun use: --match "/Extract/extract (regression tests)/works with a module that splices in an expression from an other module/"

Randomized with seed 107198347
```