### PR TITLE
Do not rely on Paths_doctest

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,2 +1,2 @@
-:set -DTEST -isrc -itest -idist/build/autogen -packageghc -optP-include -optPdist/build/autogen/cabal_macros.h
+:set -DTEST -isrc -itest -packageghc
 :set -ighci-wrapper/src

--- a/package.yaml
+++ b/package.yaml
@@ -1,3 +1,6 @@
+verbatim:
+  cabal-version: 2.0
+
 name:             doctest
 version:          0.18.2
 synopsis:         Test interactive Haskell examples

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -25,9 +25,6 @@ import           Control.Monad (when)
 import           Data.List.Compat (intercalate, stripPrefix)
 import           Data.Monoid (Endo (Endo))
 
-import qualified Paths_doctest
-import           Data.Version (showVersion)
-
 #if __GLASGOW_HASKELL__ < 900
 import           Config as GHC
 #else
@@ -54,7 +51,11 @@ usage = unlines [
   ]
 
 version :: String
-version = showVersion Paths_doctest.version
+#ifdef CURRENT_PACKAGE_VERSION
+version = CURRENT_PACKAGE_VERSION
+#else
+version = "unknown"
+#endif
 
 ghcVersion :: String
 ghcVersion = GHC.cProjectVersion

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -7,7 +7,6 @@ main = doctest [
     "-packageghc"
   , "-isrc"
   , "-ighci-wrapper/src"
-  , "-idist/build/autogen/"
   , "-optP-include"
   , "-optPdist/build/autogen/cabal_macros.h"
   , "src/Run.hs"


### PR DESCRIPTION
I'm not aware of a clean way to determine the location of `Paths_*` with `cabal v2-*`.  To be able to run `doctest` on `doctest` itself this PR gets rid of any imports of `Paths_doctest`.

This is not ideal but works for now.

I would be very eager to find a way to determine the location of `Paths_*` reliably.  However, I'm not sure if this is currently possible at all.

If somebody really needs `Path_*` then a solution might be to pass the required components in from a smaller driver-wrapper (similar to `driver/Main.hs`).  `doctest` then won't work on the driver, but it will work on the rest of the codebase.