### PR TITLE
Add "success" dummy job to github build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: doctest-CI
+name: build
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  linux:
+  build:
     name: doctest-CI Linux - GHC ${{ matrix.ghc }}
     runs-on: ubuntu-18.04
     container:
@@ -119,3 +119,12 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           (cd ghci-wrapper && cabal v1-configure --enable-tests --ghc-options=-Werror $CABAL_OPTS && cabal v1-build && cabal v1-test)
           cabal v1-configure --enable-tests --ghc-options=-Werror $CABAL_OPTS && cabal v1-build && cabal v1-test
+
+  success:
+    needs: build
+    runs-on: ubuntu-latest
+    if: always() # this is required as GitHub considers "skipped" jobs as "passed" when checking branch protection rules
+
+    steps:
+      - run: false
+        if: needs.build.result != 'success'

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3c86bef70634c1ec5f684a059a0805713b8f747ef2dcaecf351c5f773410e4d2
+-- hash: d72341386fa5019d836d102ce53149841ad11aa7bd786c3ba9b8cc28ca3c9046
 
 name:           doctest
 version:        0.18.2
@@ -241,6 +241,8 @@ test-suite spec
       ghci-wrapper/src
   c-sources:
       test/integration/with-cbits/foo.c
+  build-tool-depends:
+      hspec-discover:hspec-discover
   build-depends:
       HUnit
     , QuickCheck >=2.13.1

--- a/package.yaml
+++ b/package.yaml
@@ -67,6 +67,7 @@ executable:
 
 tests:
   spec:
+    build-tools: hspec-discover
     main: Spec.hs
     ghc-options: -threaded
     cpp-options: -DTEST


### PR DESCRIPTION
This will allow us to use branch protection rules.