### PR TITLE
Automatically tag and publish to Hackage on version bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: sol/haskell-autotag@v1
+        id: autotag
+        with:
+          prefix: null
+
+      - run: cabal sdist
+      - uses: haskell-actions/hackage-publish@v1.1
+        with:
+          hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
+          publish: true
+        if: steps.autotag.outputs.created


### PR DESCRIPTION
@andreasabel with this change, bumping the package version results in two things:

- A tag will be created automatically
- `doctest` will be released to Hackage

The job only runs on pushes to `main`. So specifically:

- We should only bump the version if we intend to release
- We should not create tags manually