### PR TITLE
GHC 9.4 Support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/parsonsmatt/primitive
+    tag: 99ebd4b81ab320b71dcffd0c20082c5b2ccbcfee
+
+

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.5.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -138,7 +138,7 @@ library
     , directory
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.3
+    , ghc >=7.0 && <9.5
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
@@ -161,7 +161,7 @@ executable doctest
     , doctest
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.3
+    , ghc >=7.0 && <9.5
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
@@ -222,7 +222,7 @@ test-suite spec
     , directory
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.3
+    , ghc >=7.0 && <9.5
     , ghc-paths >=0.1.0.9
     , hspec >=2.3.0
     , hspec-core >=2.3.0

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,7 @@ ghc-options: -Wall
 dependencies:
 - base >= 4.5 && < 5
 - base-compat >= 0.7.0
-- ghc >= 7.0 && < 9.3
+- ghc >= 7.0 && < 9.5
 - syb >= 0.3
 - code-page >= 0.1
 - deepseq

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:             doctest
-version:          0.20.0
+version:          0.20.1
 synopsis:         Test interactive Haskell examples
 description: |
   `doctest` is a tool that checks [examples](https://www.haskell.org/haddock/doc/html/ch03s08.html#idm140354810775744)

--- a/test/ExtractSpec.hs
+++ b/test/ExtractSpec.hs
@@ -36,7 +36,7 @@ spec = do
     it "extracts documentation for a top-level declaration" $ do
       ("declaration", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" Some documentation"]]
 
-    it "extracts documentation from argument list" $ do
+    focus $ it "extracts documentation from argument list" $ do
       ("argument-list", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" doc for arg1", " doc for arg2"]]
 
     it "extracts documentation for a type class function" $ do


### PR DESCRIPTION
Looks like this one might be more complicated.

Test suite fails from running `cabal test` with a `ghcup` provided GHC 9.4:

```

Failures:

  test/MainSpec.hs:128:7:
  1) Main, doctest as a runner for QuickCheck properties, runs a boolean property
       property-bool ["Foo.hs"]
       expected: Examples: 1  Tried: 1  Errors: 0  Failures: 0
        but got: Examples: 1  Tried: 1  Errors: 0  Failures: 1

  To rerun use: --match "/Main/doctest as a runner for QuickCheck properties/runs a boolean property/"

  test/MainSpec.hs:132:7:
  2) Main, doctest as a runner for QuickCheck properties, runs an explicitly quantified property
       property-quantified ["Foo.hs"]
       expected: Examples: 1  Tried: 1  Errors: 0  Failures: 0
        but got: Examples: 1  Tried: 1  Errors: 0  Failures: 1

  To rerun use: --match "/Main/doctest as a runner for QuickCheck properties/runs an explicitly quantified property/"

  test/MainSpec.hs:136:7:
  3) Main, doctest as a runner for QuickCheck properties, runs an implicitly quantified property
       property-implicitly-quantified ["Foo.hs"]
       expected: Examples: 1  Tried: 1  Errors: 0  Failures: 0
        but got: Examples: 1  Tried: 1  Errors: 0  Failures: 1

  To rerun use: --match "/Main/doctest as a runner for QuickCheck properties/runs an implicitly quantified property/"

  test/MainSpec.hs:144:7:
  4) Main, doctest as a runner for QuickCheck properties, runs a boolean property with an explicit type signature
       property-bool-with-type-signature ["Foo.hs"]
       expected: Examples: 1  Tried: 1  Errors: 0  Failures: 0
        but got: Examples: 1  Tried: 1  Errors: 0  Failures: 1

  To rerun use: --match "/Main/doctest as a runner for QuickCheck properties/runs a boolean property with an explicit type signature/"

  test/MainSpec.hs:148:7:
  5) Main, doctest as a runner for QuickCheck properties, runs $setup before each property
       property-setup ["Foo.hs"]
       expected: Examples: 3  Tried: 3  Errors: 0  Failures: 0
        but got: Examples: 3  Tried: 1  Errors: 0  Failures: 1

  To rerun use: --match "/Main/doctest as a runner for QuickCheck properties/runs $setup before each property/"

  test/PropertySpec.hs:21:32:
  6) Property.runProperty reports a failing property
       expected: Failure "*** Failed! Falsified (after 1 test):"
        but got: Failure "\n<interactive>:32:3: error:\n    Variable not in scope:\n      polyQuickCheck\n        :: Language.Haskell.TH.Syntax.Name\n           -> Language.Haskell.TH.Lib.Internal.ExpQ"

  To rerun use: --match "/Property/runProperty/reports a failing property/"

  test/PropertySpec.hs:24:31:
  7) Property.runProperty runs a Bool property
       expected: Success
        but got: Failure "\n<interactive>:32:3: error:\n    Variable not in scope:\n      polyQuickCheck\n        :: Language.Haskell.TH.Syntax.Name\n           -> Language.Haskell.TH.Lib.Internal.ExpQ"

  To rerun use: --match "/Property/runProperty/runs a Bool property/"

  test/PropertySpec.hs:27:39:
  8) Property.runProperty runs a Bool property with an explicit type signature
       expected: Success
        but got: Failure "\n<interactive>:32:3: error:\n    Variable not in scope:\n      polyQuickCheck\n        :: Language.Haskell.TH.Syntax.Name\n           -> Language.Haskell.TH.Lib.Internal.ExpQ"

  To rerun use: --match "/Property/runProperty/runs a Bool property with an explicit type signature/"

  test/PropertySpec.hs:30:66:
  9) Property.runProperty runs an implicitly quantified property
       expected: Success
        but got: Failure "\n<interactive>:32:3: error:\n    Variable not in scope:\n      polyQuickCheck\n        :: Language.Haskell.TH.Syntax.Name\n           -> Language.Haskell.TH.Lib.Internal.ExpQ"

  To rerun use: --match "/Property/runProperty/runs an implicitly quantified property/"

  test/PropertySpec.hs:42:64:
  10) Property.runProperty runs an implicitly quantified property even with GHC 7.4
       expected: Success
        but got: Failure "\n<interactive>:32:3: error:\n    Variable not in scope:\n      polyQuickCheck\n        :: Language.Haskell.TH.Syntax.Name\n           -> Language.Haskell.TH.Lib.Internal.ExpQ"

  To rerun use: --match "/Property/runProperty/runs an implicitly quantified property even with GHC 7.4/"

  test/PropertySpec.hs:46:74:
  11) Property.runProperty runs an explicitly quantified property
       expected: Success
        but got: Failure "\n<interactive>:32:3: error:\n    Variable not in scope:\n      polyQuickCheck\n        :: Language.Haskell.TH.Syntax.Name\n           -> Language.Haskell.TH.Lib.Internal.ExpQ"

  To rerun use: --match "/Property/runProperty/runs an explicitly quantified property/"

  test/PropertySpec.hs:49:48:
  12) Property.runProperty allows to mix implicit and explicit quantification
       expected: Success
        but got: Failure "\n<interactive>:32:3: error:\n    Variable not in scope:\n      polyQuickCheck\n        :: Language.Haskell.TH.Syntax.Name\n           -> Language.Haskell.TH.Lib.Internal.ExpQ"

  To rerun use: --match "/Property/runProperty/allows to mix implicit and explicit quantification/"

  test/PropertySpec.hs:52:34:
  13) Property.runProperty reports the value for which a property fails
       expected: Failure "*** Failed! Falsified (after 1 test):\n0"
        but got: Failure "\n<interactive>:32:3: error:\n    Variable not in scope:\n      polyQuickCheck\n        :: Language.Haskell.TH.Syntax.Name\n           -> Language.Haskell.TH.Lib.Internal.ExpQ"

  To rerun use: --match "/Property/runProperty/reports the value for which a property fails/"

  test/PropertySpec.hs:56:75:
  14) Property.runProperty reports the values for which a property that takes multiple arguments fails
       expected: ["False", "0", "\"\""]
        but got: ["<interactive>:32:3: error:", "    Variable not in scope:", "      polyQuickCheck", "        :: Language.Haskell.TH.Syntax.Name", "           -> Language.Haskell.TH.Lib.Internal.ExpQ"]

  To rerun use: --match "/Property/runProperty/reports the values for which a property that takes multiple arguments fails/"

  test/RunSpec.hs:87:5:
  15) Run.doctest prints verbose description of a property
       uncaught exception: ExitCode
       ExitFailure 1

  To rerun use: --match "/Run/doctest/prints verbose description of a property/"

  test/RunSpec.hs:116:5:
  16) Run.doctest can deal with potentially problematic GHC options
       uncaught exception: ExitCode
       ExitFailure 1

  To rerun use: --match "/Run/doctest/can deal with potentially problematic GHC options/"

Randomized with seed 108586937

Finished in 9.8986 seconds
177 examples, 16 failures

Test suite spec: FAIL
Test suite logged to:
/home/matt/Projects/doctest/dist-newstyle/build/x86_64-linux/ghc-9.2.2/doctest-0.20.0/t/spec/test/doctest-0.20.0-spec.log
0 of 1 test suites (0 of 1 test cases) passed.
cabal: Tests failed for test:spec from doctest-0.20.0.
```