### PR TITLE
Initial support for GHC 9.4

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -138,7 +138,7 @@ library
     , directory
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.3
+    , ghc >=7.0 && <9.5
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
@@ -161,7 +161,7 @@ executable doctest
     , doctest
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.3
+    , ghc >=7.0 && <9.5
     , ghc-paths >=0.1.0.9
     , process
     , syb >=0.3
@@ -222,7 +222,7 @@ test-suite spec
     , directory
     , exceptions
     , filepath
-    , ghc >=7.0 && <9.3
+    , ghc >=7.0 && <9.5
     , ghc-paths >=0.1.0.9
     , hspec >=2.3.0
     , hspec-core >=2.3.0

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,7 @@ ghc-options: -Wall
 dependencies:
 - base >= 4.5 && < 5
 - base-compat >= 0.7.0
-- ghc >= 7.0 && < 9.3
+- ghc >= 7.0 && < 9.5
 - syb >= 0.3
 - code-page >= 0.1
 - deepseq

--- a/src/Extract.hs
+++ b/src/Extract.hs
@@ -181,11 +181,7 @@ parse args = withGhc args $ \modules_ -> withTempOutputDir $ do
       _ <- setSessionDynFlags (GHC.ms_hspp_opts modsum)
       hsc_env <- getSession
 
-# if __GLASGOW_HASKELL__ >= 903
-      hsc_env' <- liftIO (initializePlugins hsc_env Nothing)
-      setSession hsc_env'
-      return $ modsum
-# elif __GLASGOW_HASKELL__ >= 901
+# if __GLASGOW_HASKELL__ >= 902
       hsc_env' <- liftIO (initializePlugins hsc_env)
       setSession hsc_env'
       return $ modsum
@@ -225,6 +221,11 @@ extractFromModule m = Module name (listToMaybe $ map snd setup) (map snd docs)
     (setup, docs) = partition isSetup (docStringsFromModule m)
     name = (moduleNameString . GHC.moduleName . ms_mod . pm_mod_summary) m
 
+#if __GLASGOW_HASKELL__ >= 904
+unpackHDS :: HsDocString -> String
+unpackHDS = renderHsDocString
+#endif
+
 -- | Extract all docstrings from given module.
 docStringsFromModule :: ParsedModule -> [(Maybe String, Located String)]
 docStringsFromModule mod = map (fmap (toLocated . fmap unpackHDS)) docs
@@ -232,13 +233,23 @@ docStringsFromModule mod = map (fmap (toLocated . fmap unpackHDS)) docs
     source   = (unLoc . pm_parsed_source) mod
 
     -- we use dlist-style concatenation here
+    docs :: [(Maybe String, LHsDocString)]
     docs     = header ++ exports ++ decls
 
     -- We process header, exports and declarations separately instead of
     -- traversing the whole source in a generic way, to ensure that we get
     -- everything in source order.
+#if __GLASGOW_HASKELL__ >= 904
+    header  = [(Nothing, hsDocString <$> x) | Just x <- [hsmodHaddockModHeader source]]
+#else
     header  = [(Nothing, x) | Just x <- [hsmodHaddockModHeader source]]
+#endif
+    exports :: [(Maybe String, LHsDocString)]
+#if __GLASGOW_HASKELL__ >= 904
+    exports = [ (Nothing, L (locA loc) (hsDocString (unLoc doc)))
+#else
     exports = [ (Nothing, L (locA loc) doc)
+#endif
 #if __GLASGOW_HASKELL__ < 710
               | L loc (IEDoc doc) <- concat (hsmodExports source)
 #elif __GLASGOW_HASKELL__ < 805
@@ -247,6 +258,7 @@ docStringsFromModule mod = map (fmap (toLocated . fmap unpackHDS)) docs
               | L loc (IEDoc _ doc) <- maybe [] unLoc (hsmodExports source)
 #endif
               ]
+    decls :: [(Maybe String, LHsDocString)]
     decls   = extractDocStrings (hsmodDecls source)
 
 type Selector a = a -> ([(Maybe String, LHsDocString)], Bool)
@@ -319,10 +331,17 @@ extractDocStrings = everythingBut (++) (([], False) `mkQ` fromLHsDecl
     fromLHsDocString :: Selector LHsDocString
     fromLHsDocString x = select (Nothing, x)
 
+#if __GLASGOW_HASKELL__ >= 904
+    fromDocDecl :: SrcSpan -> DocDecl GhcPs -> (Maybe String, LHsDocString)
+    fromDocDecl loc x = case x of
+      DocCommentNamed name doc -> (Just name, L loc (hsDocString (unLoc doc)))
+      _                        -> (Nothing, L loc (hsDocString (unLoc (docDeclDoc x))))
+#else
     fromDocDecl :: SrcSpan -> DocDecl -> (Maybe String, LHsDocString)
     fromDocDecl loc x = case x of
       DocCommentNamed name doc -> (Just name, L loc doc)
       _                        -> (Nothing, L loc $ docDeclDoc x)
+#endif
 
 #if __GLASGOW_HASKELL__ < 805
 -- | Convert a docstring to a plain string.


### PR DESCRIPTION
This PR would be better than #375 since doctest can be compiled with GHC 9.4.
Unfortunately, four test cases fail.
But I believe that this is a good start point for discussion.

I confirmed that GHC 9.0 and GHC 9.2 works well.

Cc: @parsonsmatt