### PR TITLE
Don't run `doctest` with `cabal exec`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,8 @@ jobs:
       - run: cabal exec -- cabal test all --test-show-details=direct
         env:
           HSPEC_OPTIONS: --color
-      - run: cabal exec -- cabal repl --with-ghc=doctest
+      - run: cabal install
+      - run: cabal repl --with-ghc=doctest
 
   success:
     needs: build


### PR DESCRIPTION
(this results in a stack overflow with GHC 9.4.*)