### PR TITLE
Add cabal-doctest exe as cabal external command

### DIFF
--- a/doctest.cabal
+++ b/doctest.cabal
@@ -184,6 +184,20 @@ executable doctest
   if impl(ghc >= 9.8)
     ghc-options: -fno-warn-x-partial
 
+executable cabal-doctest
+  main-is: CabalWrapper.hs
+  ghc-options: -Wall -threaded
+  hs-source-dirs:
+      driver
+  build-depends:
+      base >=4.5 && <5
+    , doctest
+    , ghc-paths >=0.1.0.9
+    , process
+  default-language: Haskell2010
+  if impl(ghc >= 9.8)
+    ghc-options: -fno-warn-x-partial
+
 test-suite spec
   main-is: Spec.hs
   other-modules:

--- a/driver/CabalWrapper.hs
+++ b/driver/CabalWrapper.hs
@@ -1,0 +1,44 @@
+module Main (main) where
+
+import GHC.Paths (ghc_pkg)
+import System.Environment (getArgs, getEnvironment, getExecutablePath, lookupEnv)
+import System.Exit (exitWith)
+import qualified System.Process as P
+import Test.DocTest (doctest)
+import Prelude
+
+main :: IO ()
+main = getArgs >>= dispatch
+
+{- | Check if @$CABAL@ is defined to see if used as cabal external command or as
+a compiler, then run corresponding actions.
+-}
+dispatch :: [String] -> IO ()
+dispatch args = do
+    mCabal <- lookupEnv cabalEnvVariable
+    case mCabal of
+        Nothing -> doctest args
+        -- Drop first arg
+        -- See: https://cabal.readthedocs.io/en/latest/external-commands.html
+        Just cabal -> cabalRepl cabal (drop 1 args)
+
+-- | Run as external cabal command: run cabal repl with relevant compiler options
+cabalRepl :: String -> [String] -> IO ()
+cabalRepl cabal args = do
+    exePath <- getExecutablePath
+    -- Remove `cabalEnvVariable` from the environment, else we will get an infinite loop
+    cur_env <- getEnvironment
+    let new_env = filter ((/= cabalEnvVariable) . fst) cur_env
+    -- Run doctest via cabal repl
+    exitCode <-
+        P.withCreateProcess
+            (P.proc cabal (mkArgs exePath args)){P.env = Just new_env}
+            (\_ _ _ p -> P.waitForProcess p)
+    exitWith exitCode
+  where
+    mkArgs exePath opts = baseOpts exePath ++ opts
+    baseOpts exePath = ["repl", "--with-compiler", exePath, "--with-hc-pkg", ghc_pkg]
+
+-- | Environment variable passed by cabal when calling external command
+cabalEnvVariable :: String
+cabalEnvVariable = "CABAL"


### PR DESCRIPTION
Following the discussion in haskell/cabal#10057, this PR adds the executable `cabal-doctest` to be use as a [cabal external command](https://cabal.readthedocs.io/en/latest/external-commands.html), like so:

```bash
# Equivalent of cabal repl --with-compiler=doctest
# *if* the GHC currently in PATH is the same used to compiled doctest
cabal doctest
# Equivalent of the previous, although not the intended use
CABAL=cabal cabal-doctest
# If we have various doctests compiled with different GHC version, such as `doctest-X.Y`,
# this will run just fine while cabal repl --with-compiler=doctest-X.Y may raise an error
# due to ghc-pkg version mismatch
cabal doctest-9.2
cabal doctest-9.4
…
cabal doctest-9.8
```

Fixes #396 