### PR TITLE
Add `cabal-doctest`

### DIFF
--- a/.github/workflows/cabal-doctest.yml
+++ b/.github/workflows/cabal-doctest.yml
@@ -1,0 +1,50 @@
+name: cabal-doctest
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-12
+          - windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: ghcup install cabal latest --set
+        if: matrix.os == 'macos-12'
+
+      - run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        if: matrix.os == 'macos-12'
+
+      - run: cabal --version
+      - run: cabal update
+      - run: cabal install
+      - run: cabal doctest
+
+  cabal-doctest-success:
+    needs: build
+    runs-on: ubuntu-latest
+    if: always() # this is required as GitHub considers "skipped" jobs as "passed" when checking branch protection rules
+
+    steps:
+      - run: false
+        if: needs.build.result != 'success'

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -157,6 +157,27 @@ library
   if impl(ghc >= 9.8)
     ghc-options: -fno-warn-x-partial
 
+executable cabal-doctest
+  main-is: driver/cabal-doctest.hs
+  other-modules:
+      Paths_doctest
+  default-extensions:
+      NamedFieldPuns
+      RecordWildCards
+      DeriveFunctor
+      NoImplicitPrelude
+  ghc-options: -Wall -threaded
+  build-depends:
+      base >=4.7 && <5
+    , filepath
+    , process
+    , temporary
+  default-language: Haskell2010
+  if impl(ghc >= 9.0)
+    ghc-options: -fwarn-unused-packages
+  if impl(ghc >= 9.8)
+    ghc-options: -fno-warn-x-partial
+
 executable doctest
   main-is: driver/doctest.hs
   other-modules:

--- a/driver/cabal-doctest.hs
+++ b/driver/cabal-doctest.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE LambdaCase #-}
+module Main (main) where
+
+import           Prelude
+
+import           Data.Version
+import           System.Environment
+import           System.Exit
+import           System.FilePath
+import           System.IO.Temp (withSystemTempDirectory)
+import           System.Process
+
+import           Paths_doctest (version)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  lookupEnv "CABAL" >>= \ case
+    Nothing -> run "cabal" args
+    Just cabal -> run cabal (drop 1 args)
+
+run :: String -> [String] -> IO ()
+run cabal args = withSystemTempDirectory "doctest" $ \ dir -> do
+  let
+    doctest = dir </> "doctest"
+    script = dir </> "init-ghci"
+  callProcess cabal ["install", "--ignore-project", "--installdir", dir, "--install-method=symlink", "doctest-" ++ showVersion version]
+  callProcess (dir </> "doctest") ["--version"]
+  callProcess cabal ("build" : "--only-dependencies" : args)
+  writeFile script ":seti -w -Wdefault"
+  spawnProcess cabal ("repl"
+    : "--build-depends=QuickCheck"
+    : "--build-depends=template-haskell"
+    : ("--repl-options=-ghci-script=" ++ script)
+    : "--with-compiler" : doctest
+    : args) >>= waitForProcess >>= exitWith

--- a/package.yaml
+++ b/package.yaml
@@ -64,11 +64,20 @@ library:
     ghc-paths: ">= 0.1.0.9"
     transformers:
 
-executable:
-  main: driver/doctest.hs
-  ghc-options: -threaded
-  dependencies:
-    - doctest
+executables:
+  doctest:
+    main: driver/doctest.hs
+    ghc-options: -threaded
+    dependencies:
+      - doctest
+
+  cabal-doctest:
+    main: driver/cabal-doctest.hs
+    ghc-options: -threaded
+    dependencies:
+      - process
+      - filepath
+      - temporary
 
 tests:
   spec:


### PR DESCRIPTION
Based on https://github.com/mpickering/cabal-doctest-demo/blob/master/cabal-doctest

Follow-ups:

- [ ] Cache the `doctest` executables
- [ ] Add support for `-w`, e.g. `-w 9.10.1`