### PR TITLE
Release 0.22.5

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+Changes in 0.22.5
+  - Add (experimental) `cabal-doctest` executable.  This is guarded behind a
+    flag for now, use `cabal install doctest -f -cabal-doctest` to install it.
+
 Changes in 0.22.4
   - Use `-Wno-unused-packages` for GHC `8.10` / `9.0` / `9.2`
 

--- a/doctest.cabal
+++ b/doctest.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           doctest
-version:        0.22.4
+version:        0.22.5
 synopsis:       Test interactive Haskell examples
 description:    `doctest` is a tool that checks [examples](https://www.haskell.org/haddock/doc/html/ch03s08.html#idm140354810775744)
                 and [properties](https://www.haskell.org/haddock/doc/html/ch03s08.html#idm140354810771856)
@@ -107,6 +107,11 @@ source-repository head
   type: git
   location: https://github.com/sol/doctest
 
+flag cabal-doctest
+  description: Install (experimental) cabal-doctest executable
+  manual: True
+  default: False
+
 library
   ghc-options: -Wall
   hs-source-dirs:
@@ -177,6 +182,10 @@ executable cabal-doctest
     ghc-options: -fwarn-unused-packages
   if impl(ghc >= 9.8)
     ghc-options: -fno-warn-x-partial
+  if flag(cabal-doctest)
+    buildable: True
+  else
+    buildable: False
 
 executable doctest
   main-is: driver/doctest.hs

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:             doctest
-version:          0.22.4
+version:          0.22.5
 synopsis:         Test interactive Haskell examples
 description: |
   `doctest` is a tool that checks [examples](https://www.haskell.org/haddock/doc/html/ch03s08.html#idm140354810775744)
@@ -64,6 +64,12 @@ library:
     ghc-paths: ">= 0.1.0.9"
     transformers:
 
+flags:
+  cabal-doctest:
+    description: Install (experimental) cabal-doctest executable
+    manual: true
+    default: false
+
 executables:
   doctest:
     main: driver/doctest.hs
@@ -78,6 +84,12 @@ executables:
       - process
       - filepath
       - temporary
+    when:
+      condition: flag(cabal-doctest)
+      then:
+        buildable: true
+      else:
+        buildable: false
 
 tests:
   spec:


### PR DESCRIPTION
Changes in 0.22.5
  - Add (experimental) `cabal-doctest` executable.  This is guarded behind a
    flag for now, use `cabal install doctest -f -cabal-doctest` to install it.
