### PR TITLE
cabal-doctest: Fix handling of options with optional arguments

### DIFF
--- a/.github/workflows/cabal-doctest.yml
+++ b/.github/workflows/cabal-doctest.yml
@@ -42,7 +42,7 @@ jobs:
       - run: cabal path
       - run: cabal update
       - run: cabal install -f cabal-doctest
-      - run: cabal doctest
+      - run: cabal doctest --allow-newer=False
 
       - run: cabal doctest -w ghc-9.6
       - run: cabal doctest -w ghc-8.6.5

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+Changes in 0.22.8
+  - cabal-doctest: Fix handling of options with optional arguments
+
 Changes in 0.22.7
   - cabal-doctest: Accept component
   - cabal-doctest: Get rid of separate `cabal build` step

--- a/src/Cabal/Options.hs
+++ b/src/Cabal/Options.hs
@@ -71,4 +71,8 @@ documentedOptions = map toOptDescr Repl.options
 
 discardReplOptions :: [String] -> [String]
 discardReplOptions args = case getOpt Permute options args of
-  (xs, _, _) -> concat [name : maybeToList value | Argument name value <- xs, Set.notMember name replOnlyOptions]
+  (xs, _, _) -> [renderArgument name value | Argument name value <- xs, Set.notMember name replOnlyOptions]
+  where
+    renderArgument name = \ case
+      Nothing -> name
+      Just value -> name <> "=" <> value

--- a/test/Cabal/OptionsSpec.hs
+++ b/test/Cabal/OptionsSpec.hs
@@ -57,4 +57,4 @@ spec = do
         , "--repl-options", "foo"
         , "--repl-options=foo"
         , "--allow-newer"
-        ] `shouldBe` ["--with-compiler", "ghc-9.10", "--disable-optimization", "--allow-newer"]
+        ] `shouldBe` ["--with-compiler=ghc-9.10", "--disable-optimization", "--allow-newer"]


### PR DESCRIPTION
(e.g. `--allow-newer=False`)