### PR TITLE
add --output-file=FILENAME option

### DIFF
--- a/src/Run.hs
+++ b/src/Run.hs
@@ -15,9 +15,9 @@ module Run (
 , doctestWithResult
 
 , runDocTests
-
-
-
+#ifdef TEST
+, expandDirs
+#endif
 ) where
 
 import           Imports
@@ -31,11 +31,11 @@ import           System.IO.CodePage (withCP65001)
 
 import qualified Control.Exception as E
 
-
-
-
+#if __GLASGOW_HASKELL__ < 900
+import           Panic
+#else
 import           GHC.Utils.Panic
-
+#endif
 
 import           PackageDBs
 import           Parse

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -15,9 +15,9 @@ module Run (
 , doctestWithResult
 
 , runDocTests
-#ifdef TEST
-, expandDirs
-#endif
+
+
+
 ) where
 
 import           Imports
@@ -31,11 +31,11 @@ import           System.IO.CodePage (withCP65001)
 
 import qualified Control.Exception as E
 
-#if __GLASGOW_HASKELL__ < 900
-import           Panic
-#else
+
+
+
 import           GHC.Utils.Panic
-#endif
+
 
 import           PackageDBs
 import           Parse
@@ -157,4 +157,5 @@ runDocTests Config{..} modules = do
   Interpreter.withInterpreter ((<> ghcOptions) <$> repl) $ \ interpreter -> withCP65001 $ do
     let
       v = if verbose then Verbose else NonVerbose
-    runModules fastMode preserveIt v interpreter modules
+      outputFile' = maybe StdErr File outputFile
+    runModules fastMode preserveIt v interpreter outputFile' modules

--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -90,7 +90,9 @@ runModules fastMode preserveIt verbose repl outputTo modules = withLineBuffering
         reportProgress
         forM_ modules $ runModule fastMode preserveIt repl
         verboseReport "# Final summary:"
-      hClose file
+      case outputTo of
+        File _ -> hClose file
+        StdErr -> pass
 
   run `finally` reportFinalResult
 


### PR DESCRIPTION
add --output-file=FILENAME option to cause test outputs to be logged to FILENAME instead of stderr (the default)

We need this because currently we get swamped by doctest outputs.  Redirection of standard error doesn't seem to work because it's hCaptured.

More specifically, the reason we need this is we use doctests for the class worksheets in a Haskell course.  we run doctest from a stack test, with an automated watcher, rerunning on file change. The problem is that when the student first starts each worksheet (a file with around a dozen exercise functions to implement and several test cases per exercise) they have a file with a whole lot of functions whose body starts off as `undefined`.  The doctest for each such function fails and their terminal is swamped with output, they have to scroll back to the top to find the first failure - usually the one they are actively working on.  If instead, we can send the output to a file, they can view just the head of the file and see the first failure or two on a single screen.  

It may sound trivial, but it would actually be a game changer for us.  It's a big class - about 600 students this year, at a major Australian university and a wide range of skill and experience levels.  The less we overwhelm them the better.