### PR TITLE
Fix linting issues in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 
       - run: cabal update
       - run: cabal build
-      - run: cabal exec $(cabal list-bin spec)
+      - run: cabal exec "$(cabal list-bin spec)"
       - run: cabal install
       - run: cabal repl --with-compiler=doctest
 
@@ -101,6 +101,6 @@ jobs:
       - run: false
         if: needs.build.result != 'success'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: curl -sSL https://raw.githubusercontent.com/sol/hpack/main/get-hpack.sh | bash
       - run: hpack && git diff --color --exit-code


### PR DESCRIPTION
Hi :)

I'm testing the library with GHC912 and the `haskell-actions` one is already supporting that. In this PR I did some updates to the GHA build job, in particular:

1. I've substituted the [hspec setup action](https://github.com/hspec/setup-haskell) with the [haskell-actions one](https://github.com/haskell-actions/setup). **Note**: `cabal update` is done by default by the used action.

2. Replaced `macOS-12` environment which is deprecated.

3. I've also run [actionlint](https://github.com/rhysd/actionlint) and addressed those issues. Here is the output of that tool:
```
.github/workflows/build.yml:121:9: shellcheck reported issue in this script: SC2046:warning:1:12: Quote this to prevent word splitting [shellcheck]
    |
121 |       - run: cabal exec $(cabal list-bin spec)
    |         ^~~~
.github/workflows/build.yml:136:15: the runner of "actions/checkout@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
    |
136 |       - uses: actions/checkout@v3
    |               ^~~~~~~~~~~~~~~~~~~
```

---
I've prepared this during this event
[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://lu.ma/open-source-saturday-torino)