### PR TITLE
Disable `allow-newer=base` workaround.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,6 @@
 packages:
   .
 
-allow-newer: base
-
 package doctest
   ghc-options: -Werror
 


### PR DESCRIPTION
This PR reverts the `allow-newer=base` workaround introduced in PR #478.
